### PR TITLE
Implement avatar generation flow

### DIFF
--- a/src/app/components/upload-photo/upload-photo.component.css
+++ b/src/app/components/upload-photo/upload-photo.component.css
@@ -6,10 +6,9 @@ button {
   margin-left: 0.5rem;
 }
 
-img {
-  max-width: 200px;
-  display: block;
-  margin-top: 1rem;
+
+.loading {
+  margin-top: 0.5rem;
 }
 
 .error {

--- a/src/app/components/upload-photo/upload-photo.component.html
+++ b/src/app/components/upload-photo/upload-photo.component.html
@@ -1,8 +1,8 @@
 <div class="upload-form">
   <input type="file" (change)="onFileSelected($event)" />
-  <button (click)="removeBackground()" [disabled]="!selectedFile">Process</button>
+  <button (click)="generateAvatar()" [disabled]="!selectedFile || loading">
+    Create Avatar
+  </button>
 </div>
+<div class="loading" *ngIf="loading">Generating avatar...</div>
 <div class="error" *ngIf="error">{{ error }}</div>
-<div *ngIf="processedUrl">
-  <img [src]="processedUrl" alt="Processed" />
-</div>

--- a/src/app/components/upload-photo/upload-photo.component.ts
+++ b/src/app/components/upload-photo/upload-photo.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
-import { RemoveBgService } from '../../services/removebg.service';
+import { Router } from '@angular/router';
+import { AvatarService } from '../../services/avatar.service';
 
 @Component({
   selector: 'app-upload-photo',
@@ -8,10 +9,13 @@ import { RemoveBgService } from '../../services/removebg.service';
 })
 export class UploadPhotoComponent {
   selectedFile?: File;
-  processedUrl?: string;
   error?: string;
+  loading = false;
 
-  constructor(private removeBgService: RemoveBgService) {}
+  constructor(
+    private avatarService: AvatarService,
+    private router: Router
+  ) {}
 
   onFileSelected(event: Event) {
     const element = event.target as HTMLInputElement;
@@ -21,16 +25,20 @@ export class UploadPhotoComponent {
     }
   }
 
-  async removeBackground() {
+  async generateAvatar() {
     if (!this.selectedFile) {
       this.error = 'Please select a file first.';
       return;
     }
+    this.loading = true;
     try {
       this.error = undefined;
-      this.processedUrl = await this.removeBgService.removeBackground(this.selectedFile);
+      await this.avatarService.createAvatar(this.selectedFile);
+      this.router.navigate(['/avatar']);
     } catch (err) {
-      this.error = 'Failed to process image.';
+      this.error = 'Failed to generate avatar.';
+    } finally {
+      this.loading = false;
     }
   }
 }

--- a/src/app/services/avatar.service.ts
+++ b/src/app/services/avatar.service.ts
@@ -1,11 +1,31 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class AvatarService {
+  private generatedUrl?: string;
+
   constructor(private http: HttpClient) {}
 
+  async createAvatar(file: File): Promise<string> {
+    const formData = new FormData();
+    formData.append('photo', file);
+
+    // Placeholder API call - replace with real 3DLOOK endpoint
+    const response = await firstValueFrom(
+      this.http.post<{ avatarUrl: string }>('https://api.3dlook.com/avatar', formData)
+    );
+
+    this.generatedUrl = response.avatarUrl;
+    return response.avatarUrl;
+  }
+
   async getAvatarUrl(): Promise<string> {
+    if (this.generatedUrl) {
+      return this.generatedUrl;
+    }
+
     // Placeholder: integrate with 3DLOOK or Ready Player Me
     // Return a demo avatar stored in assets
     return 'assets/avatar-default.glb';


### PR DESCRIPTION
## Summary
- add avatar creation API call in `AvatarService`
- send upload to `AvatarService` and navigate to `/avatar`
- display a loading state while creating the avatar

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685075aa3da4832e9d6c61e033e8354d