### PR TITLE
Add avatar preview step

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -4,3 +4,4 @@
 - [x] Upload Photo page validates file selection and displays errors
 - [x] Avatar View page loads a demo avatar and shows an error if loading fails
 - [x] Mix & Match page lists outfit items and shows a message when none are available
+- [ ] Avatar Preview page shows the generated avatar and a Next button

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 This is a demo Angular application for experimenting with a virtual closet experience. It includes placeholder integrations for external services such as Ready Player Me, Remove.bg and Firebase.
 
-The UI provides three main pages:
+The UI provides the following pages:
 1. **Upload Photo** – process an image with background removal.
-2. **Avatar View** – preview a sample 3D avatar.
-3. **Mix & Match** – list outfit items in a simple mix and match interface.
+2. **Avatar Preview** – display the generated avatar with an option to continue.
+3. **Avatar View** – preview a sample 3D avatar.
+4. **Mix & Match** – list outfit items in a simple mix and match interface.
 
 ## Development
 

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,10 +3,12 @@ import { RouterModule, Routes } from '@angular/router';
 import { UploadPhotoComponent } from './components/upload-photo/upload-photo.component';
 import { AvatarViewComponent } from './components/avatar-view/avatar-view.component';
 import { MixMatchComponent } from './components/mix-match/mix-match.component';
+import { AvatarPreviewComponent } from './components/avatar-preview/avatar-preview.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'upload', pathMatch: 'full' },
   { path: 'upload', component: UploadPhotoComponent },
+  { path: 'avatar-preview', component: AvatarPreviewComponent },
   { path: 'avatar', component: AvatarViewComponent },
   { path: 'mix-match', component: MixMatchComponent },
   { path: '**', redirectTo: 'upload' }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,13 +8,15 @@ import { AppComponent } from './app.component';
 import { AvatarViewComponent } from './components/avatar-view/avatar-view.component';
 import { UploadPhotoComponent } from './components/upload-photo/upload-photo.component';
 import { MixMatchComponent } from './components/mix-match/mix-match.component';
+import { AvatarPreviewComponent } from './components/avatar-preview/avatar-preview.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     AvatarViewComponent,
     UploadPhotoComponent,
-    MixMatchComponent
+    MixMatchComponent,
+    AvatarPreviewComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/avatar-preview/avatar-preview.component.css
+++ b/src/app/components/avatar-preview/avatar-preview.component.css
@@ -1,0 +1,5 @@
+img {
+  max-width: 100%;
+  display: block;
+  margin-bottom: 1rem;
+}

--- a/src/app/components/avatar-preview/avatar-preview.component.html
+++ b/src/app/components/avatar-preview/avatar-preview.component.html
@@ -1,0 +1,7 @@
+<div *ngIf="avatarUrl; else noAvatar">
+  <img [src]="avatarUrl" alt="Avatar Preview" />
+</div>
+<ng-template #noAvatar>
+  <p>No avatar to display.</p>
+</ng-template>
+<button (click)="next()">Next</button>

--- a/src/app/components/avatar-preview/avatar-preview.component.ts
+++ b/src/app/components/avatar-preview/avatar-preview.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-avatar-preview',
+  templateUrl: './avatar-preview.component.html',
+  styleUrls: ['./avatar-preview.component.css']
+})
+export class AvatarPreviewComponent {
+  avatarUrl?: string;
+
+  constructor(private router: Router) {
+    const navigation = this.router.getCurrentNavigation();
+    this.avatarUrl = navigation?.extras.state?.['avatarUrl'];
+  }
+
+  next(): void {
+    this.router.navigate(['/avatar']);
+  }
+}

--- a/src/app/components/upload-photo/upload-photo.component.ts
+++ b/src/app/components/upload-photo/upload-photo.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
 import { RemoveBgService } from '../../services/removebg.service';
 
 @Component({
@@ -11,7 +12,7 @@ export class UploadPhotoComponent {
   processedUrl?: string;
   error?: string;
 
-  constructor(private removeBgService: RemoveBgService) {}
+  constructor(private removeBgService: RemoveBgService, private router: Router) {}
 
   onFileSelected(event: Event) {
     const element = event.target as HTMLInputElement;
@@ -29,6 +30,7 @@ export class UploadPhotoComponent {
     try {
       this.error = undefined;
       this.processedUrl = await this.removeBgService.removeBackground(this.selectedFile);
+      this.router.navigate(['/avatar-preview'], { state: { avatarUrl: this.processedUrl } });
     } catch (err) {
       this.error = 'Failed to process image.';
     }


### PR DESCRIPTION
## Summary
- build AvatarPreviewComponent for the generated avatar screen
- pass avatar URL from upload step via router state
- route `/avatar-preview` for the new screen
- navigate there after removing background
- document the new page in README

## Testing
- `npx ng test --watch=false --no-progress --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_685075ac7c84832eb08917917b237187