### PR TITLE
Add outfit upload step

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,11 +3,13 @@ import { RouterModule, Routes } from '@angular/router';
 import { UploadPhotoComponent } from './components/upload-photo/upload-photo.component';
 import { AvatarViewComponent } from './components/avatar-view/avatar-view.component';
 import { MixMatchComponent } from './components/mix-match/mix-match.component';
+import { UploadOutfitsComponent } from './components/upload-outfits/upload-outfits.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'upload', pathMatch: 'full' },
   { path: 'upload', component: UploadPhotoComponent },
   { path: 'avatar', component: AvatarViewComponent },
+  { path: 'upload-outfits', component: UploadOutfitsComponent },
   { path: 'mix-match', component: MixMatchComponent },
   { path: '**', redirectTo: 'upload' }
 ];

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,6 +3,7 @@
   <nav>
     <a routerLink="/upload" routerLinkActive="active">Upload Photo</a>
     <a routerLink="/avatar" routerLinkActive="active">Avatar View</a>
+    <a routerLink="/upload-outfits" routerLinkActive="active">Upload Outfits</a>
     <a routerLink="/mix-match" routerLinkActive="active">Mix & Match</a>
   </nav>
 </header>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,13 +8,15 @@ import { AppComponent } from './app.component';
 import { AvatarViewComponent } from './components/avatar-view/avatar-view.component';
 import { UploadPhotoComponent } from './components/upload-photo/upload-photo.component';
 import { MixMatchComponent } from './components/mix-match/mix-match.component';
+import { UploadOutfitsComponent } from './components/upload-outfits/upload-outfits.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     AvatarViewComponent,
     UploadPhotoComponent,
-    MixMatchComponent
+    MixMatchComponent,
+    UploadOutfitsComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/upload-outfits/upload-outfits.component.css
+++ b/src/app/components/upload-outfits/upload-outfits.component.css
@@ -1,0 +1,21 @@
+.upload-outfits {
+  margin-bottom: 1rem;
+}
+
+select {
+  margin-right: 0.5rem;
+}
+
+button {
+  margin-left: 0.5rem;
+}
+
+img {
+  max-width: 100px;
+  margin: 0.5rem;
+}
+
+.error {
+  color: #c00;
+  margin-top: 0.5rem;
+}

--- a/src/app/components/upload-outfits/upload-outfits.component.html
+++ b/src/app/components/upload-outfits/upload-outfits.component.html
@@ -1,0 +1,18 @@
+<div class="upload-outfits">
+  <label>
+    Category
+    <select [(ngModel)]="selectedCategory">
+      <option *ngFor="let c of categories" [value]="c">{{ c }}</option>
+    </select>
+  </label>
+  <input type="file" multiple (change)="onFilesSelected($event)" />
+  <button (click)="uploadAll()" [disabled]="!selectedFiles.length || isUploading">
+    Upload
+  </button>
+</div>
+<div class="error" *ngIf="error">{{ error }}</div>
+<ul *ngIf="uploadedUrls.length">
+  <li *ngFor="let url of uploadedUrls">
+    <img [src]="url" alt="Uploaded" />
+  </li>
+</ul>

--- a/src/app/components/upload-outfits/upload-outfits.component.ts
+++ b/src/app/components/upload-outfits/upload-outfits.component.ts
@@ -1,0 +1,54 @@
+import { Component } from '@angular/core';
+import { RemoveBgService } from '../../services/removebg.service';
+import { FirebaseService } from '../../services/firebase.service';
+
+@Component({
+  selector: 'app-upload-outfits',
+  templateUrl: './upload-outfits.component.html',
+  styleUrls: ['./upload-outfits.component.css']
+})
+export class UploadOutfitsComponent {
+  categories = ['Hat', 'Shirt', 'Pants', 'Shoes'];
+  selectedCategory = this.categories[0];
+  selectedFiles: File[] = [];
+  uploadedUrls: string[] = [];
+  isUploading = false;
+  error?: string;
+
+  constructor(
+    private removeBgService: RemoveBgService,
+    private firebaseService: FirebaseService
+  ) {}
+
+  onFilesSelected(event: Event) {
+    const files = (event.target as HTMLInputElement).files;
+    if (files) {
+      this.selectedFiles = Array.from(files);
+    }
+  }
+
+  async uploadAll() {
+    if (!this.selectedFiles.length) {
+      this.error = 'Please select images.';
+      return;
+    }
+    this.error = undefined;
+    this.isUploading = true;
+    this.uploadedUrls = [];
+    for (const file of this.selectedFiles) {
+      try {
+        await this.removeBgService.removeBackground(file);
+        const url = await this.firebaseService.uploadFile(file);
+        await this.firebaseService.saveOutfit({
+          category: this.selectedCategory,
+          imageUrl: url
+        });
+        this.uploadedUrls.push(url);
+      } catch {
+        this.error = 'Failed to upload files.';
+        break;
+      }
+    }
+    this.isUploading = false;
+  }
+}


### PR DESCRIPTION
## Summary
- create UploadOutfitsComponent for multi-image clothing uploads
- store outfit metadata through FirebaseService and process images with RemoveBgService
- declare UploadOutfitsComponent in AppModule
- route `/upload-outfits` added after avatar preview
- link new route from main navigation

## Testing
- `npx ng build`
- `npx ng test --watch=false` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_685075aea030832e9a05c037299e7fbc