### PR TITLE
Add Virtual Closet drag‑drop page

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -4,3 +4,4 @@
 - [x] Upload Photo page validates file selection and displays errors
 - [x] Avatar View page loads a demo avatar and shows an error if loading fails
 - [x] Mix & Match page lists outfit items and shows a message when none are available
+- [ ] Virtual Closet allows styling the avatar and saving outfits

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 This is a demo Angular application for experimenting with a virtual closet experience. It includes placeholder integrations for external services such as Ready Player Me, Remove.bg and Firebase.
 
-The UI provides three main pages:
+The UI provides four main pages:
 1. **Upload Photo** – process an image with background removal.
 2. **Avatar View** – preview a sample 3D avatar.
 3. **Mix & Match** – list outfit items in a simple mix and match interface.
+4. **Virtual Closet** – style an avatar with draggable outfit pieces.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@angular/animations": "~17.0.0",
+    "@angular/cdk": "^17.3.10",
     "@angular/common": "~17.0.0",
     "@angular/compiler": "~17.0.0",
     "@angular/core": "~17.0.0",
@@ -33,7 +34,6 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-
     "typescript": "~5.2.0"
   }
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,12 +3,14 @@ import { RouterModule, Routes } from '@angular/router';
 import { UploadPhotoComponent } from './components/upload-photo/upload-photo.component';
 import { AvatarViewComponent } from './components/avatar-view/avatar-view.component';
 import { MixMatchComponent } from './components/mix-match/mix-match.component';
+import { VirtualClosetComponent } from './components/virtual-closet/virtual-closet.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'upload', pathMatch: 'full' },
   { path: 'upload', component: UploadPhotoComponent },
   { path: 'avatar', component: AvatarViewComponent },
   { path: 'mix-match', component: MixMatchComponent },
+  { path: 'closet', component: VirtualClosetComponent },
   { path: '**', redirectTo: 'upload' }
 ];
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,6 +4,7 @@
     <a routerLink="/upload" routerLinkActive="active">Upload Photo</a>
     <a routerLink="/avatar" routerLinkActive="active">Avatar View</a>
     <a routerLink="/mix-match" routerLinkActive="active">Mix & Match</a>
+    <a routerLink="/closet" routerLinkActive="active">Virtual Closet</a>
   </nav>
 </header>
 <main>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,24 +3,28 @@ import { BrowserModule } from '@angular/platform-browser';
 import { HttpClientModule } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 import { AppRoutingModule } from './app-routing.module';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 
 import { AppComponent } from './app.component';
 import { AvatarViewComponent } from './components/avatar-view/avatar-view.component';
 import { UploadPhotoComponent } from './components/upload-photo/upload-photo.component';
 import { MixMatchComponent } from './components/mix-match/mix-match.component';
+import { VirtualClosetComponent } from './components/virtual-closet/virtual-closet.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     AvatarViewComponent,
     UploadPhotoComponent,
-    MixMatchComponent
+    MixMatchComponent,
+    VirtualClosetComponent
   ],
   imports: [
     BrowserModule,
     HttpClientModule,
     FormsModule,
-    AppRoutingModule
+    AppRoutingModule,
+    DragDropModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/components/virtual-closet/virtual-closet.component.css
+++ b/src/app/components/virtual-closet/virtual-closet.component.css
@@ -1,0 +1,50 @@
+.closet-container {
+  position: relative;
+  width: 100%;
+  height: 400px;
+  margin: 1rem auto;
+  border: 1px solid #ccc;
+  overflow: hidden;
+}
+
+.avatar {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.avatar img {
+  max-width: 200px;
+}
+
+.piece {
+  position: absolute;
+  width: 80px;
+  cursor: move;
+}
+
+.save {
+  display: block;
+  margin: 0.5rem auto;
+}
+
+.message {
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
+.action-bar {
+  display: flex;
+  justify-content: space-around;
+  margin-top: 1rem;
+}
+
+.action-bar button {
+  background: none;
+  border: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 1.2rem;
+}

--- a/src/app/components/virtual-closet/virtual-closet.component.html
+++ b/src/app/components/virtual-closet/virtual-closet.component.html
@@ -1,0 +1,21 @@
+<div class="closet-container">
+  <div class="avatar" *ngIf="avatarUrl">
+    <img [src]="avatarUrl" alt="Avatar" />
+  </div>
+  <img
+    *ngFor="let piece of pieces"
+    class="piece"
+    [src]="piece.url"
+    cdkDrag
+    [cdkDragFreeDragPosition]="{x: piece.x, y: piece.y}"
+    (cdkDragEnded)="onDragEnd($event, piece)"
+  />
+</div>
+<button class="save" (click)="save()" [disabled]="saving">Save Outfit</button>
+<div class="message" *ngIf="message">{{ message }}</div>
+<nav class="action-bar">
+  <button><span>🏠</span><div>Home</div></button>
+  <button><span>🧥</span><div>Wardrobe</div></button>
+  <button><span>🛒</span><div>Cart</div></button>
+  <button><span>👤</span><div>Profile</div></button>
+</nav>

--- a/src/app/components/virtual-closet/virtual-closet.component.ts
+++ b/src/app/components/virtual-closet/virtual-closet.component.ts
@@ -1,0 +1,60 @@
+import { Component, OnInit } from '@angular/core';
+import { CdkDragEnd } from '@angular/cdk/drag-drop';
+import { AvatarService } from '../../services/avatar.service';
+import { FirebaseService } from '../../services/firebase.service';
+
+interface ClosetItem {
+  url: string;
+  x: number;
+  y: number;
+}
+
+@Component({
+  selector: 'app-virtual-closet',
+  templateUrl: './virtual-closet.component.html',
+  styleUrls: ['./virtual-closet.component.css']
+})
+export class VirtualClosetComponent implements OnInit {
+  avatarUrl?: string | null;
+  pieces: ClosetItem[] = [];
+  saving = false;
+  message?: string;
+
+  constructor(private avatarService: AvatarService,
+              private firebaseService: FirebaseService) {}
+
+  ngOnInit(): void {
+    this.loadAvatar();
+    // Demo outfit pieces
+    this.pieces = [
+      { url: 'assets/item1.png', x: -120, y: 0 },
+      { url: 'assets/item2.png', x: 120, y: 0 }
+    ];
+  }
+
+  async loadAvatar() {
+    this.avatarUrl = await this.avatarService.getAvatarUrl();
+  }
+
+  onDragEnd(event: CdkDragEnd, piece: ClosetItem) {
+    const pos = event.source.getFreeDragPosition();
+    piece.x = pos.x;
+    piece.y = pos.y;
+  }
+
+  async save() {
+    this.saving = true;
+    this.message = undefined;
+    try {
+      await this.firebaseService.saveOutfit({
+        avatar: this.avatarUrl,
+        pieces: this.pieces
+      });
+      this.message = 'Outfit saved.';
+    } catch {
+      this.message = 'Save failed.';
+    } finally {
+      this.saving = false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create Virtual Closet component
- show the avatar and draggable outfit pieces
- add bottom action bar
- enable drag-drop module and route
- document new page in README
- add placeholder checklist item

## Testing
- `npm test --silent` *(fails: Cannot find module '@angular-devkit/core')*

------
https://chatgpt.com/codex/tasks/task_e_685075b092dc832ea688f331924c3efa