### PR TITLE
Add login route and new navigation layout

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,14 +2,20 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { UploadPhotoComponent } from './components/upload-photo/upload-photo.component';
 import { AvatarViewComponent } from './components/avatar-view/avatar-view.component';
-import { MixMatchComponent } from './components/mix-match/mix-match.component';
+import { LoginComponent } from './components/login/login.component';
+import { UploadOutfitsComponent } from './components/upload-outfits/upload-outfits.component';
+import { VirtualClosetComponent } from './components/virtual-closet/virtual-closet.component';
+import { GalleryComponent } from './components/gallery/gallery.component';
 
 const routes: Routes = [
-  { path: '', redirectTo: 'upload', pathMatch: 'full' },
-  { path: 'upload', component: UploadPhotoComponent },
-  { path: 'avatar', component: AvatarViewComponent },
-  { path: 'mix-match', component: MixMatchComponent },
-  { path: '**', redirectTo: 'upload' }
+  { path: '', redirectTo: 'login', pathMatch: 'full' },
+  { path: 'login', component: LoginComponent },
+  { path: 'upload-photo', component: UploadPhotoComponent },
+  { path: 'avatar-preview', component: AvatarViewComponent },
+  { path: 'upload-outfits', component: UploadOutfitsComponent },
+  { path: 'virtual-closet', component: VirtualClosetComponent },
+  { path: 'gallery', component: GalleryComponent },
+  { path: '**', redirectTo: 'login' }
 ];
 
 @NgModule({

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -10,16 +10,27 @@ header {
   text-align: center;
 }
 
-nav a {
-  margin: 0 0.5rem;
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: #324851;
+  display: flex;
+  justify-content: space-around;
+  padding: 0.5rem 0;
+}
+
+.bottom-nav a {
   color: #fff;
   text-decoration: none;
 }
 
-nav a.active {
+.bottom-nav a.active {
   text-decoration: underline;
 }
 
 main {
   padding: 1rem;
+  padding-bottom: 3rem;
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,11 +1,12 @@
-<header>
+<header *ngIf="showNav">
   <h1>{{ title }}</h1>
-  <nav>
-    <a routerLink="/upload" routerLinkActive="active">Upload Photo</a>
-    <a routerLink="/avatar" routerLinkActive="active">Avatar View</a>
-    <a routerLink="/mix-match" routerLinkActive="active">Mix & Match</a>
-  </nav>
 </header>
 <main>
   <router-outlet></router-outlet>
 </main>
+<nav class="bottom-nav" *ngIf="showNav">
+  <a routerLink="/upload-photo" routerLinkActive="active">Home</a>
+  <a routerLink="/virtual-closet" routerLinkActive="active">Wardrobe</a>
+  <a routerLink="/cart" routerLinkActive="active">Cart</a>
+  <a routerLink="/profile" routerLinkActive="active">Profile</a>
+</nav>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter } from 'rxjs/operators';
 
 @Component({
   selector: 'app-root',
@@ -7,4 +9,13 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'UCloset3D';
+  showNav = true;
+
+  constructor(private router: Router) {
+    this.router.events
+      .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+      .subscribe(event => {
+        this.showNav = event.urlAfterRedirects !== '/login';
+      });
+  }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,13 +8,25 @@ import { AppComponent } from './app.component';
 import { AvatarViewComponent } from './components/avatar-view/avatar-view.component';
 import { UploadPhotoComponent } from './components/upload-photo/upload-photo.component';
 import { MixMatchComponent } from './components/mix-match/mix-match.component';
+import { LoginComponent } from './components/login/login.component';
+import { UploadOutfitsComponent } from './components/upload-outfits/upload-outfits.component';
+import { VirtualClosetComponent } from './components/virtual-closet/virtual-closet.component';
+import { GalleryComponent } from './components/gallery/gallery.component';
+import { CartComponent } from './components/cart/cart.component';
+import { ProfileComponent } from './components/profile/profile.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     AvatarViewComponent,
     UploadPhotoComponent,
-    MixMatchComponent
+    MixMatchComponent,
+    LoginComponent,
+    UploadOutfitsComponent,
+    VirtualClosetComponent,
+    GalleryComponent,
+    CartComponent,
+    ProfileComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/cart/cart.component.css
+++ b/src/app/components/cart/cart.component.css
@@ -1,0 +1,1 @@
+/* Cart component styles */

--- a/src/app/components/cart/cart.component.html
+++ b/src/app/components/cart/cart.component.html
@@ -1,0 +1,1 @@
+<p>Cart works!</p>

--- a/src/app/components/cart/cart.component.ts
+++ b/src/app/components/cart/cart.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-cart',
+  templateUrl: './cart.component.html',
+  styleUrls: ['./cart.component.css']
+})
+export class CartComponent {}

--- a/src/app/components/gallery/gallery.component.css
+++ b/src/app/components/gallery/gallery.component.css
@@ -1,0 +1,1 @@
+/* Gallery component styles */

--- a/src/app/components/gallery/gallery.component.html
+++ b/src/app/components/gallery/gallery.component.html
@@ -1,0 +1,1 @@
+<p>Gallery works!</p>

--- a/src/app/components/gallery/gallery.component.ts
+++ b/src/app/components/gallery/gallery.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-gallery',
+  templateUrl: './gallery.component.html',
+  styleUrls: ['./gallery.component.css']
+})
+export class GalleryComponent {}

--- a/src/app/components/login/login.component.css
+++ b/src/app/components/login/login.component.css
@@ -1,0 +1,1 @@
+/* Login component styles */

--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -1,0 +1,1 @@
+<p>Login works!</p>

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-login',
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.css']
+})
+export class LoginComponent {}

--- a/src/app/components/profile/profile.component.css
+++ b/src/app/components/profile/profile.component.css
@@ -1,0 +1,1 @@
+/* Profile component styles */

--- a/src/app/components/profile/profile.component.html
+++ b/src/app/components/profile/profile.component.html
@@ -1,0 +1,1 @@
+<p>Profile works!</p>

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-profile',
+  templateUrl: './profile.component.html',
+  styleUrls: ['./profile.component.css']
+})
+export class ProfileComponent {}

--- a/src/app/components/upload-outfits/upload-outfits.component.css
+++ b/src/app/components/upload-outfits/upload-outfits.component.css
@@ -1,0 +1,1 @@
+/* Upload outfits component styles */

--- a/src/app/components/upload-outfits/upload-outfits.component.html
+++ b/src/app/components/upload-outfits/upload-outfits.component.html
@@ -1,0 +1,1 @@
+<p>Upload outfits works!</p>

--- a/src/app/components/upload-outfits/upload-outfits.component.ts
+++ b/src/app/components/upload-outfits/upload-outfits.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-upload-outfits',
+  templateUrl: './upload-outfits.component.html',
+  styleUrls: ['./upload-outfits.component.css']
+})
+export class UploadOutfitsComponent {}

--- a/src/app/components/virtual-closet/virtual-closet.component.css
+++ b/src/app/components/virtual-closet/virtual-closet.component.css
@@ -1,0 +1,1 @@
+/* Virtual closet component styles */

--- a/src/app/components/virtual-closet/virtual-closet.component.html
+++ b/src/app/components/virtual-closet/virtual-closet.component.html
@@ -1,0 +1,1 @@
+<p>Virtual closet works!</p>

--- a/src/app/components/virtual-closet/virtual-closet.component.ts
+++ b/src/app/components/virtual-closet/virtual-closet.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-virtual-closet',
+  templateUrl: './virtual-closet.component.html',
+  styleUrls: ['./virtual-closet.component.css']
+})
+export class VirtualClosetComponent {}


### PR DESCRIPTION
## Summary
- wire up routes for login and closet features
- scaffold placeholder components for new pages
- display bottom nav with links to major sections
- hide navigation when viewing the login screen

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser on platform)*

------
https://chatgpt.com/codex/tasks/task_e_685075b53e2c832eb70e266fbc2952eb