### PR TITLE
Fix local development issues

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -25,7 +25,7 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "ucloset3d:build"
+            "buildTarget": "ucloset3d:build"
           }
 
         },

--- a/src/app/services/avatar.service.ts
+++ b/src/app/services/avatar.service.ts
@@ -1,24 +1,17 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { firstValueFrom } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class AvatarService {
   private generatedUrl?: string;
 
-  constructor(private http: HttpClient) {}
+  constructor() {}
 
   async createAvatar(file: File): Promise<string> {
-    const formData = new FormData();
-    formData.append('photo', file);
-
-    // Placeholder API call - replace with real 3DLOOK endpoint
-    const response = await firstValueFrom(
-      this.http.post<{ avatarUrl: string }>('https://api.3dlook.com/avatar', formData)
-    );
-
-    this.generatedUrl = response.avatarUrl;
-    return response.avatarUrl;
+    // In the demo environment we do not call an external API.
+    // Instead, we simply return a local placeholder avatar so the
+    // application can run without network access.
+    this.generatedUrl = 'assets/avatar-default.glb';
+    return this.generatedUrl;
   }
 
   async getAvatarUrl(): Promise<string> {


### PR DESCRIPTION
## Summary
- update avatar service to return a local placeholder instead of calling a remote API
- use `buildTarget` in `angular.json` to avoid deprecation warnings

## Testing
- `npm run build`
- `npx ng serve`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6857a2c9953c832ebfad63f583ef092e