### PR TITLE
Inject HttpClient for avatar service

### DIFF
--- a/src/app/services/avatar.service.ts
+++ b/src/app/services/avatar.service.ts
@@ -8,7 +8,7 @@ import { environment } from '../../environments/environment';
 export class AvatarService {
   private generatedUrl?: string;
 
-  constructor() {}
+  constructor(private http: HttpClient) {}
 
   async createAvatar(file: File): Promise<string> {
     const formData = new FormData();


### PR DESCRIPTION
## Summary
- inject `HttpClient` into `AvatarService`
- explicitly type avatar generation response

## Testing
- `npx tsc -p tsconfig.app.json`
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6857b6e01728832ebf1faeb367da931e