### PR TITLE
Switch avatar generation to Ready Player Me

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UCloset3D
 
-This is a demo Angular application for experimenting with a virtual closet experience. It now integrates with real services such as 3DLOOK for avatar generation, Remove.bg for background removal and Firebase for storage.
+This is a demo Angular application for experimenting with a virtual closet experience. It integrates with real services such as Ready Player Me for avatar generation, Remove.bg for background removal, BodyBlock for measurements and Firebase for storage.
 
 ## Setup
 
@@ -41,9 +41,10 @@ Add your API keys in `src/environments/environment.ts`:
 ```
 export const environment = {
   production: false,
-  threeDLookApiKey: 'YOUR_3DLOOK_API_KEY',
+  readyPlayerMeApiKey: 'YOUR_READY_PLAYER_ME_API_KEY',
   removeBgApiKey: 'YOUR_REMOVE_BG_API_KEY',
   barcodeApiKey: 'YOUR_BARCODE_API_KEY',
+  bodyBlockApiKey: 'YOUR_BODYBLOCK_API_KEY',
   firebase: {
     apiKey: 'YOUR_FIREBASE_API_KEY',
     authDomain: 'YOUR_FIREBASE_AUTH_DOMAIN',
@@ -61,19 +62,19 @@ Deploying to Firebase requires a valid Firebase project configuration. Ensure `f
 The UI provides four main pages:
 
 1. **Upload Photo** – process an image with background removal.
-2. **Avatar View** – preview a sample 3D avatar.
+2. **Avatar View** – preview a Ready Player Me avatar and measurements.
 3. **Mix & Match** – list outfit items in a simple mix and match interface.
 4. **Virtual Closet** – style an avatar with draggable outfit pieces.
 The UI provides the following pages:
 1. **Upload Photo** – process an image with background removal.
 2. **Avatar Preview** – display the generated avatar with an option to continue.
-3. **Avatar View** – preview a sample 3D avatar.
+3. **Avatar View** – preview a Ready Player Me avatar.
 4. **Mix & Match** – list outfit items in a simple mix and match interface.
 
 ## Six-Screen Workflow
 
 1. **Login** – authenticate with a demo account.
-2. **Avatar Generation** – create a personalized 3D avatar from a selfie.
+2. **Avatar Generation** – create a personalized Ready Player Me avatar and collect measurements using BodyBlock.
 3. **Outfit Uploads** – add clothing images and automatically remove the background.
 4. **Virtual Closet** – manage wardrobe items with drag‑and‑drop sorting.
 5. **Mix & Match** – arrange outfits using pieces from the virtual closet.

--- a/src/app/components/avatar-preview/avatar-preview.component.html
+++ b/src/app/components/avatar-preview/avatar-preview.component.html
@@ -1,6 +1,10 @@
 <div *ngIf="avatarUrl; else noAvatar">
   <img [src]="avatarUrl" alt="Avatar Preview" />
 </div>
+<div *ngIf="measurement">
+  <h3>Measurements</h3>
+  <pre>{{ measurement | json }}</pre>
+</div>
 <ng-template #noAvatar>
   <p>No avatar to display.</p>
 </ng-template>

--- a/src/app/components/avatar-preview/avatar-preview.component.ts
+++ b/src/app/components/avatar-preview/avatar-preview.component.ts
@@ -8,10 +8,12 @@ import { Router } from '@angular/router';
 })
 export class AvatarPreviewComponent {
   avatarUrl?: string;
+  measurement?: any;
 
   constructor(private router: Router) {
     const navigation = this.router.getCurrentNavigation();
     this.avatarUrl = navigation?.extras.state?.['avatarUrl'];
+    this.measurement = navigation?.extras.state?.['measurement'];
   }
 
   next(): void {

--- a/src/app/components/upload-photo/upload-photo.component.ts
+++ b/src/app/components/upload-photo/upload-photo.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { RemoveBgService } from '../../services/removebg.service';
 import { AvatarService } from '../../services/avatar.service';
+import { BodyBlockService } from '../../services/bodyblock.service';
 
 @Component({
   selector: 'app-upload-photo',
@@ -16,11 +17,13 @@ export class UploadPhotoComponent {
    * be passed to the avatar preview component when navigating.
    */
   processedUrl?: string;
+  measurements?: any;
   loading = false;
 
   constructor(
     private avatarService: AvatarService,
-  private removeBgService: RemoveBgService,
+    private removeBgService: RemoveBgService,
+    private bodyBlockService: BodyBlockService,
     private router: Router
   ) {}
 
@@ -41,8 +44,9 @@ export class UploadPhotoComponent {
     try {
       this.error = undefined;
       this.processedUrl = await this.removeBgService.removeBackground(this.selectedFile);
+      this.measurements = await this.bodyBlockService.measure(this.selectedFile);
       const avatarUrl = await this.avatarService.createAvatar(this.selectedFile);
-      this.router.navigate(['/avatar-preview'], { state: { avatarUrl } });
+      this.router.navigate(['/avatar-preview'], { state: { avatarUrl, measurement: this.measurements } });
 
     } catch (err) {
       this.error = 'Failed to generate avatar.';

--- a/src/app/services/avatar.service.ts
+++ b/src/app/services/avatar.service.ts
@@ -15,12 +15,12 @@ export class AvatarService {
     formData.append('photo', file);
 
     const headers = new HttpHeaders({
-      'Authorization': `Bearer ${environment.threeDLookApiKey}`
+      Authorization: `Bearer ${environment.readyPlayerMeApiKey}`
     });
 
     const response = await firstValueFrom(
       this.http.post<{ avatarUrl: string }>(
-        'https://api.3dlook.ai/v3/avatars',
+        'https://api.readyplayer.me/v1/avatars',
         formData,
         { headers }
       )
@@ -35,8 +35,7 @@ export class AvatarService {
       return this.generatedUrl;
     }
 
-    // Placeholder: integrate with 3DLOOK or Ready Player Me
-    // Return a demo avatar stored in assets
+    // Return a demo avatar stored in assets when no avatar has been generated
     return 'assets/avatar-default.glb';
   }
 }

--- a/src/app/services/bodyblock.service.ts
+++ b/src/app/services/bodyblock.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class BodyBlockService {
+  constructor(private http: HttpClient) {}
+
+  async measure(file: File): Promise<any> {
+    const formData = new FormData();
+    formData.append('image', file);
+
+    const headers = new HttpHeaders({
+      'X-Api-Key': environment.bodyBlockApiKey
+    });
+
+    return firstValueFrom(
+      this.http.post<any>('https://api.bodyblock.ai/v1/measurements', formData, {
+        headers
+      })
+    );
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,8 +1,9 @@
 export const environment = {
   production: true,
-  threeDLookApiKey: '',
+  readyPlayerMeApiKey: '',
   removeBgApiKey: '',
   barcodeApiKey: '',
+  bodyBlockApiKey: '',
   firebase: {
     apiKey: "AIzaSyCJcut6NXAuJMCx_Ce7BH8GWuKbkZHyATw",
     authDomain: "ucloset3d.firebaseapp.com",

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,8 +1,9 @@
 export const environment = {
   production: false,
-  threeDLookApiKey: 'YOUR_3DLOOK_API_KEY',
+  readyPlayerMeApiKey: 'YOUR_READY_PLAYER_ME_API_KEY',
   removeBgApiKey: 'YOUR_REMOVE_BG_API_KEY',
   barcodeApiKey: 'YOUR_BARCODE_API_KEY',
+  bodyBlockApiKey: 'YOUR_BODYBLOCK_API_KEY',
   firebase: {
     apiKey: "AIzaSyCJcut6NXAuJMCx_Ce7BH8GWuKbkZHyATw",
     authDomain: "ucloset3d.firebaseapp.com",


### PR DESCRIPTION
## Summary
- use Ready Player Me instead of 3DLOOK for avatars
- add BodyBlock service for body measurements
- show measurements on avatar preview
- document new API keys for Ready Player Me and BodyBlock

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857bde9db94832ebed5c0cf8ee037b3