### PR TITLE
Enable Firebase login

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,16 @@ export const environment = {
 
 Deploying to Firebase requires a valid Firebase project configuration. Ensure `firebase.json` has `"public": "dist/ucloset3d"` to match the Angular build output.
 
+## Authentication
 
-The UI provides four main pages:
+The login screen uses Firebase Authentication with email and password credentials. Create a user in your Firebase project and sign in with those credentials. Upon success you will be taken to the photo upload page.
 
-1. **Upload Photo** – process an image with background removal.
-2. **Avatar View** – preview a Ready Player Me avatar and measurements.
-3. **Mix & Match** – list outfit items in a simple mix and match interface.
-4. **Virtual Closet** – style an avatar with draggable outfit pieces.
 The UI provides the following pages:
 1. **Upload Photo** – process an image with background removal.
 2. **Avatar Preview** – display the generated avatar with an option to continue.
 3. **Avatar View** – preview a Ready Player Me avatar.
 4. **Mix & Match** – list outfit items in a simple mix and match interface.
+5. **Virtual Closet** – style an avatar with draggable outfit pieces.
 
 ## Six-Screen Workflow
 

--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -8,6 +8,7 @@
     Password
     <input type="password" formControlName="password" />
   </label>
-  <button type="submit">Login</button>
+  <button type="submit" [disabled]="loading">Login</button>
+  <div class="error" *ngIf="error">{{ error }}</div>
 </form>
 

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-login',
@@ -9,21 +10,36 @@ import { Router } from '@angular/router';
 })
 export class LoginComponent {
   form: FormGroup;
+  error?: string;
+  loading = false;
 
-  constructor(private fb: FormBuilder, private router: Router) {
+  constructor(
+    private fb: FormBuilder,
+    private router: Router,
+    private authService: AuthService
+  ) {
     this.form = this.fb.group({
       email: ['', [Validators.required, Validators.email]],
       password: ['', Validators.required]
     });
   }
 
-  submit() {
-    if (this.form.valid) {
-      // In a real app you would authenticate here. We simply navigate
-      // to the next step of the demo workflow.
+  async submit() {
+    if (this.form.invalid) {
+      return;
+    }
 
-      console.log('Login', this.form.value);
+    this.error = undefined;
+    this.loading = true;
+    const { email, password } = this.form.value;
+
+    try {
+      await this.authService.login(email, password);
       this.router.navigate(['/upload-photo']);
+    } catch {
+      this.error = 'Login failed.';
+    } finally {
+      this.loading = false;
     }
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { initializeApp } from 'firebase/app';
+import { getAuth, signInWithEmailAndPassword, UserCredential } from 'firebase/auth';
+import { environment } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private app = initializeApp(environment.firebase);
+  private auth = getAuth(this.app);
+
+  login(email: string, password: string): Promise<UserCredential> {
+    return signInWithEmailAndPassword(this.auth, email, password);
+  }
+}


### PR DESCRIPTION
## Summary
- hook up login form to Firebase authentication
- add a Firebase `AuthService`
- update login UI with basic error handling
- document how to sign in using Firebase in the README

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857bfca4ea8832eb8807940a4c448fe