### PR TITLE
Improve offline behavior for avatar creation

### DIFF
--- a/src/app/services/bodyblock.service.ts
+++ b/src/app/services/bodyblock.service.ts
@@ -8,6 +8,18 @@ export class BodyBlockService {
   constructor(private http: HttpClient) {}
 
   async measure(file: File): Promise<any> {
+    if (
+      !environment.bodyBlockApiKey ||
+      environment.bodyBlockApiKey.includes('YOUR_BODYBLOCK_API_KEY')
+    ) {
+      console.warn('BodyBlock API key not configured; returning mock measurements');
+      return {
+        chest: 0,
+        waist: 0,
+        hip: 0
+      };
+    }
+
     const formData = new FormData();
     formData.append('image', file);
 
@@ -15,10 +27,19 @@ export class BodyBlockService {
       'X-Api-Key': environment.bodyBlockApiKey
     });
 
-    return firstValueFrom(
-      this.http.post<any>('https://api.bodyblock.ai/v1/measurements', formData, {
-        headers
-      })
-    );
+    try {
+      return await firstValueFrom(
+        this.http.post<any>('https://api.bodyblock.ai/v1/measurements', formData, {
+          headers
+        })
+      );
+    } catch (err) {
+      console.error('Failed to fetch measurements from BodyBlock', err);
+      return {
+        chest: 0,
+        waist: 0,
+        hip: 0
+      };
+    }
   }
 }

--- a/src/app/services/removebg.service.ts
+++ b/src/app/services/removebg.service.ts
@@ -8,6 +8,14 @@ export class RemoveBgService {
   constructor(private http: HttpClient) {}
 
   async removeBackground(file: File): Promise<string> {
+    if (
+      !environment.removeBgApiKey ||
+      environment.removeBgApiKey.includes('YOUR_REMOVE_BG_API_KEY')
+    ) {
+      console.warn('Remove.bg API key not configured; returning original image');
+      return URL.createObjectURL(file);
+    }
+
     const formData = new FormData();
     formData.append('image_file', file);
 
@@ -15,13 +23,18 @@ export class RemoveBgService {
       'X-Api-Key': environment.removeBgApiKey
     });
 
-    const response = await firstValueFrom(
-      this.http.post('https://api.remove.bg/v1.0/removebg', formData, {
-        headers,
-        responseType: 'blob'
-      })
-    );
+    try {
+      const response = await firstValueFrom(
+        this.http.post('https://api.remove.bg/v1.0/removebg', formData, {
+          headers,
+          responseType: 'blob'
+        })
+      );
 
-    return URL.createObjectURL(response);
+      return URL.createObjectURL(response);
+    } catch (err) {
+      console.error('Failed to remove background via API', err);
+      return URL.createObjectURL(file);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- handle missing Ready Player Me API key in `AvatarService`
- return original image when remove.bg API key is missing
- supply mock measurements when BodyBlock API key isn't configured

## Testing
- `npm test` *(fails: No Chrome binary)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6857c0b92f00832e8eaeb4ca4bc289e0