### PR TITLE
Add sign-up page for Firebase auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Deploying to Firebase requires a valid Firebase project configuration. Ensure `f
 
 ## Authentication
 
-The login screen uses Firebase Authentication with email and password credentials. Create a user in your Firebase project and sign in with those credentials. Upon success you will be taken to the photo upload page.
+The login screen uses Firebase Authentication with email and password credentials. You can create an account using the new **Sign Up** page at `/signup` and then sign in with those credentials. Upon success you will be taken to the photo upload page.
 
 The UI provides the following pages:
 1. **Upload Photo** – process an image with background removal.

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { UploadPhotoComponent } from './components/upload-photo/upload-photo.component';
 import { AvatarViewComponent } from './components/avatar-view/avatar-view.component';
 import { LoginComponent } from './components/login/login.component';
+import { SignupComponent } from './components/signup/signup.component';
 import { UploadOutfitsComponent } from './components/upload-outfits/upload-outfits.component';
 import { VirtualClosetComponent } from './components/virtual-closet/virtual-closet.component';
 import { GalleryComponent } from './components/gallery/gallery.component';
@@ -14,6 +15,7 @@ import { AvatarPreviewComponent } from './components/avatar-preview/avatar-previ
 const routes: Routes = [
   { path: '', redirectTo: 'login', pathMatch: 'full' },
   { path: 'login', component: LoginComponent },
+  { path: 'signup', component: SignupComponent },
   { path: 'upload-photo', component: UploadPhotoComponent },
   { path: 'avatar', component: AvatarViewComponent },
   { path: 'avatar-preview', component: AvatarPreviewComponent },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { AvatarViewComponent } from './components/avatar-view/avatar-view.compon
 import { UploadPhotoComponent } from './components/upload-photo/upload-photo.component';
 import { MixMatchComponent } from './components/mix-match/mix-match.component';
 import { LoginComponent } from './components/login/login.component';
+import { SignupComponent } from './components/signup/signup.component';
 import { UploadOutfitsComponent } from './components/upload-outfits/upload-outfits.component';
 import { VirtualClosetComponent } from './components/virtual-closet/virtual-closet.component';
 import { GalleryComponent } from './components/gallery/gallery.component';
@@ -26,6 +27,7 @@ import { AdBannerComponent } from './components/ad-banner/ad-banner.component';
     UploadPhotoComponent,
     MixMatchComponent,
     LoginComponent,
+    SignupComponent,
     UploadOutfitsComponent,
     VirtualClosetComponent,
     GalleryComponent,

--- a/src/app/components/signup/signup.component.css
+++ b/src/app/components/signup/signup.component.css
@@ -1,0 +1,7 @@
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 300px;
+  margin: 2rem auto;
+}

--- a/src/app/components/signup/signup.component.html
+++ b/src/app/components/signup/signup.component.html
@@ -1,4 +1,3 @@
-
 <form [formGroup]="form" (ngSubmit)="submit()" class="login-form">
   <label>
     Email
@@ -8,11 +7,10 @@
     Password
     <input type="password" formControlName="password" />
   </label>
-  <button type="submit" [disabled]="loading">Login</button>
+  <button type="submit" [disabled]="loading">Sign Up</button>
   <div class="error" *ngIf="error">{{ error }}</div>
 </form>
 <p>
-  Don't have an account?
-  <a routerLink="/signup">Sign up</a>
+  Already have an account?
+  <a routerLink="/login">Log in</a>
 </p>
-

--- a/src/app/components/signup/signup.component.ts
+++ b/src/app/components/signup/signup.component.ts
@@ -1,0 +1,43 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-signup',
+  templateUrl: './signup.component.html',
+  styleUrls: ['./signup.component.css']
+})
+export class SignupComponent {
+  form: FormGroup;
+  error?: string;
+  loading = false;
+
+  constructor(
+    private fb: FormBuilder,
+    private router: Router,
+    private authService: AuthService
+  ) {
+    this.form = this.fb.group({
+      email: ['', [Validators.required, Validators.email]],
+      password: ['', Validators.required]
+    });
+  }
+
+  async submit() {
+    if (this.form.invalid) {
+      return;
+    }
+    this.error = undefined;
+    this.loading = true;
+    const { email, password } = this.form.value;
+    try {
+      await this.authService.signup(email, password);
+      this.router.navigate(['/login']);
+    } catch {
+      this.error = 'Sign up failed.';
+    } finally {
+      this.loading = false;
+    }
+  }
+}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { initializeApp } from 'firebase/app';
-import { getAuth, signInWithEmailAndPassword, UserCredential } from 'firebase/auth';
+import { getAuth, signInWithEmailAndPassword, createUserWithEmailAndPassword, UserCredential } from 'firebase/auth';
 import { environment } from '../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
@@ -10,5 +10,9 @@ export class AuthService {
 
   login(email: string, password: string): Promise<UserCredential> {
     return signInWithEmailAndPassword(this.auth, email, password);
+  }
+
+  signup(email: string, password: string): Promise<UserCredential> {
+    return createUserWithEmailAndPassword(this.auth, email, password);
   }
 }


### PR DESCRIPTION
## Summary
- add `signup` component for account creation
- extend `AuthService` with `signup` method
- wire new component into routing and module declarations
- link from login page to sign-up page
- mention sign-up page in README

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c4f0ec54832e98c585d1046b71f0