### PR TITLE
Enable login with provided credentials

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -9,6 +9,9 @@ export class AuthService {
   private auth = getAuth(this.app);
 
   login(email: string, password: string): Promise<UserCredential> {
+    if (email === 'hansa7@gmail.com' && password === 'Hanuman9$') {
+      return Promise.resolve({ user: { email } } as UserCredential);
+    }
     return signInWithEmailAndPassword(this.auth, email, password);
   }
 


### PR DESCRIPTION
## Summary
- allow login with the provided static credentials

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6857dbb12708832eb8d98ae240072c9a