### PR TITLE
Fix ClosetItem type mismatch

### DIFF
--- a/src/app/components/virtual-closet/virtual-closet.component.ts
+++ b/src/app/components/virtual-closet/virtual-closet.component.ts
@@ -5,13 +5,7 @@ import { AvatarService } from '../../services/avatar.service';
 import { FirebaseService } from '../../services/firebase.service';
 import { OutfitGeneratorService } from '../../services/outfit-generator.service';
 import { Router } from '@angular/router';
-
-interface ClosetItem {
-  url: string;
-  category?: string;
-  x: number;
-  y: number;
-}
+import { ClosetItem } from '../../models/closet-item';
 
 
 @Component({

--- a/src/app/models/closet-item.ts
+++ b/src/app/models/closet-item.ts
@@ -1,0 +1,6 @@
+export interface ClosetItem {
+  url: string;
+  category?: string;
+  x?: number;
+  y?: number;
+}

--- a/src/app/services/outfit-generator.service.ts
+++ b/src/app/services/outfit-generator.service.ts
@@ -1,12 +1,6 @@
 import { Injectable } from '@angular/core';
 import { FirebaseService } from './firebase.service';
-
-interface ClosetItem {
-  url: string;
-  category?: string;
-  x?: number;
-  y?: number;
-}
+import { ClosetItem } from '../models/closet-item';
 
 @Injectable({ providedIn: 'root' })
 export class OutfitGeneratorService {


### PR DESCRIPTION
## Summary
- centralize `ClosetItem` interface
- import shared interface in outfit generator service
- import shared interface in virtual closet component

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e051a34c832ebd4c2a04dd4e9cc4