### PR TITLE
Enable drag-and-drop uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Deploying to Firebase requires a valid Firebase project configuration. Ensure `f
 The login screen uses Firebase Authentication with email and password credentials. You can create an account using the new **Sign Up** page at `/signup` and then sign in with those credentials. Upon success you will be taken to the photo upload page.
 
 The UI provides the following pages:
-1. **Upload Photo** – process an image with background removal.
+1. **Upload Photo** – process an image with background removal. Drag and drop or select a file to begin.
 2. **Avatar Preview** – display the generated avatar with an option to continue.
 3. **Avatar View** – preview a Ready Player Me avatar.
 4. **Mix & Match** – list outfit items in a simple mix and match interface.
@@ -73,7 +73,7 @@ The UI provides the following pages:
 
 1. **Login** – authenticate with a demo account.
 2. **Avatar Generation** – create a personalized Ready Player Me avatar and collect measurements using BodyBlock.
-3. **Outfit Uploads** – add clothing images and automatically remove the background.
+3. **Outfit Uploads** – add clothing images with drag-and-drop support and automatically remove the background.
 4. **Virtual Closet** – manage wardrobe items with drag‑and‑drop sorting.
 5. **Mix & Match** – arrange outfits using pieces from the virtual closet.
 6. **Gallery Sharing** – publish completed looks to a shareable gallery page.

--- a/src/app/components/upload-outfits/upload-outfits.component.css
+++ b/src/app/components/upload-outfits/upload-outfits.component.css
@@ -20,3 +20,10 @@ img {
   /* Color and spacing handled globally */
 }
 
+.drop-zone {
+  border: 2px dashed #ccc;
+  padding: 1rem;
+  text-align: center;
+  margin: 0.5rem 0;
+}
+

--- a/src/app/components/upload-outfits/upload-outfits.component.html
+++ b/src/app/components/upload-outfits/upload-outfits.component.html
@@ -7,6 +7,13 @@
     </select>
   </label>
   <input type="file" multiple (change)="onFilesSelected($event)" />
+  <div
+    class="drop-zone"
+    (dragover)="onDragOver($event)"
+    (drop)="onDrop($event)"
+  >
+    Drop outfit images here
+  </div>
   <button (click)="uploadAll()" [disabled]="!selectedFiles.length || isUploading">
     Save
   </button>

--- a/src/app/components/upload-outfits/upload-outfits.component.ts
+++ b/src/app/components/upload-outfits/upload-outfits.component.ts
@@ -23,6 +23,18 @@ export class UploadOutfitsComponent {
     private router: Router
   ) {}
 
+  onDragOver(event: DragEvent) {
+    event.preventDefault();
+  }
+
+  onDrop(event: DragEvent) {
+    event.preventDefault();
+    const files = event.dataTransfer?.files;
+    if (files) {
+      this.selectedFiles = Array.from(files);
+    }
+  }
+
   onFilesSelected(event: Event) {
     const files = (event.target as HTMLInputElement).files;
     if (files) {

--- a/src/app/components/upload-photo/upload-photo.component.css
+++ b/src/app/components/upload-photo/upload-photo.component.css
@@ -14,3 +14,10 @@ button {
 .error {
   /* Color and spacing handled globally */
 }
+
+.drop-zone {
+  border: 2px dashed #ccc;
+  padding: 1rem;
+  text-align: center;
+  margin-top: 0.5rem;
+}

--- a/src/app/components/upload-photo/upload-photo.component.html
+++ b/src/app/components/upload-photo/upload-photo.component.html
@@ -1,5 +1,12 @@
 <div class="upload-form">
   <input type="file" (change)="onFileSelected($event)" />
+  <div
+    class="drop-zone"
+    (dragover)="onDragOver($event)"
+    (drop)="onDrop($event)"
+  >
+    Drop photo here
+  </div>
   <button (click)="generateAvatar()" [disabled]="!selectedFile || loading">
     Create Avatar
   </button>

--- a/src/app/components/upload-photo/upload-photo.component.ts
+++ b/src/app/components/upload-photo/upload-photo.component.ts
@@ -27,6 +27,18 @@ export class UploadPhotoComponent {
     private router: Router
   ) {}
 
+  onDragOver(event: DragEvent) {
+    event.preventDefault();
+  }
+
+  onDrop(event: DragEvent) {
+    event.preventDefault();
+    const files = event.dataTransfer?.files;
+    if (files && files.length) {
+      this.selectedFile = files[0];
+    }
+  }
+
   onFileSelected(event: Event) {
     const element = event.target as HTMLInputElement;
     const file = element.files && element.files[0];


### PR DESCRIPTION
## Summary
- make photo and outfit upload components handle drag-and-drop
- add drop zone styling for both components
- mention drag-and-drop uploading in the README

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*
- `npx ng test --watch=false` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_6857e47bc110832eaed989f57a835957