### PR TITLE
Add open-source avatar service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UCloset3D
 
-This is a demo Angular application for experimenting with a virtual closet experience. It integrates with real services such as Ready Player Me for avatar generation, Remove.bg for background removal, BodyBlock for measurements and Firebase for storage.
+This is a demo Angular application for experimenting with a virtual closet experience. It integrates with Firebase for storage and can generate avatars using either Ready Player Me or a local open‑source pipeline.
 
 ## Setup
 
@@ -34,6 +34,24 @@ npm run build
 Deploy to Firebase Hosting:
 
 firebase deploy
+
+### Optional open-source avatar server
+
+The project can generate avatars locally using open-source tools. A small Flask
+server is provided in `backend/` as a starting point. It returns a demo avatar
+and sample measurements but can be extended with projects like
+[SMPL-Anthropometry](https://github.com/sergeyprokudin/smpl-anthropometry) or
+[3d-body-measurements](https://github.com/korrair/3d-body-measurements).
+
+Start the server with:
+
+```bash
+pip install -r backend/requirements.txt
+npm run start:avatar-api
+```
+
+Then set `openAvatarApiUrl` in `src/environments/environment.ts` to the server
+URL, e.g. `http://localhost:5000`.
 ## Configuration
 
 Add your API keys in `src/environments/environment.ts`:
@@ -45,6 +63,7 @@ export const environment = {
   removeBgApiKey: 'YOUR_REMOVE_BG_API_KEY',
   barcodeApiKey: 'YOUR_BARCODE_API_KEY',
   bodyBlockApiKey: 'YOUR_BODYBLOCK_API_KEY',
+  openAvatarApiUrl: '',
   firebase: {
     apiKey: 'YOUR_FIREBASE_API_KEY',
     authDomain: 'YOUR_FIREBASE_AUTH_DOMAIN',
@@ -65,14 +84,14 @@ The login screen uses Firebase Authentication with email and password credential
 The UI provides the following pages:
 1. **Upload Photo** – process an image with background removal. Drag and drop or select a file to begin.
 2. **Avatar Preview** – display the generated avatar with an option to continue.
-3. **Avatar View** – preview a Ready Player Me avatar.
+3. **Avatar View** – preview the generated avatar.
 4. **Mix & Match** – list outfit items in a simple mix and match interface.
 5. **Virtual Closet** – style an avatar with draggable outfit pieces.
 
 ## Six-Screen Workflow
 
 1. **Login** – authenticate with a demo account.
-2. **Avatar Generation** – create a personalized Ready Player Me avatar and collect measurements using BodyBlock.
+2. **Avatar Generation** – create a personalized avatar using either Ready Player Me or the optional open-source pipeline and collect measurements.
 3. **Outfit Uploads** – add clothing images with drag-and-drop support and automatically remove the background.
 4. **Virtual Closet** – manage wardrobe items with drag‑and‑drop sorting.
 5. **Mix & Match** – arrange outfits using pieces from the virtual closet.

--- a/backend/avatar_api.py
+++ b/backend/avatar_api.py
@@ -1,0 +1,36 @@
+import os
+from flask import Flask, request, send_file, jsonify
+import numpy as np
+
+app = Flask(__name__)
+
+# Path to a default avatar shipped with the frontend for demo purposes
+DEFAULT_AVATAR_PATH = os.path.join(os.path.dirname(__file__), '..', 'src', 'assets', 'avatar-default.glb')
+
+@app.route('/generate-avatar', methods=['POST'])
+def generate_avatar():
+    """Generate a 3D avatar from a user photo using open-source tools.
+    This implementation returns a demo avatar file but can be replaced with
+    SMPL-based generation.
+    """
+    if not os.path.exists(DEFAULT_AVATAR_PATH):
+        return 'Avatar asset missing', 500
+    return send_file(DEFAULT_AVATAR_PATH, mimetype='model/gltf-binary')
+
+@app.route('/measurements', methods=['POST'])
+def measurements():
+    """Return basic body measurements computed from the user photo.
+    Currently returns mock values. Integrate with projects like
+    3d-body-measurements for real results.
+    """
+    rng = np.random.default_rng()
+    data = {
+        'chest': float(rng.uniform(80, 100)),
+        'waist': float(rng.uniform(60, 90)),
+        'hip': float(rng.uniform(80, 100))
+    }
+    return jsonify(data)
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+flask
+numpy

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "start:avatar-api": "python backend/avatar_api.py"
   },
   "dependencies": {
     "@angular/animations": "~17.0.0",

--- a/src/app/services/avatar.service.ts
+++ b/src/app/services/avatar.service.ts
@@ -11,6 +11,26 @@ export class AvatarService {
   constructor(private http: HttpClient) {}
 
   async createAvatar(file: File): Promise<string> {
+    // Prefer the optional open-source avatar API when configured
+    if (environment.openAvatarApiUrl) {
+      const formData = new FormData();
+      formData.append('photo', file);
+      try {
+        const blob = await firstValueFrom(
+          this.http.post(
+            `${environment.openAvatarApiUrl}/generate-avatar`,
+            formData,
+            { responseType: 'blob' }
+          )
+        );
+        this.generatedUrl = URL.createObjectURL(blob);
+        return this.generatedUrl;
+      } catch (err) {
+        console.error('Failed to generate avatar from open-source API', err);
+        return 'assets/avatar-default.glb';
+      }
+    }
+
     if (
       !environment.readyPlayerMeApiKey ||
       environment.readyPlayerMeApiKey.includes('YOUR_READY_PLAYER_ME_API_KEY')

--- a/src/app/services/bodyblock.service.ts
+++ b/src/app/services/bodyblock.service.ts
@@ -8,6 +8,23 @@ export class BodyBlockService {
   constructor(private http: HttpClient) {}
 
   async measure(file: File): Promise<any> {
+    // Use the optional open-source avatar API when configured
+    if (environment.openAvatarApiUrl) {
+      const formData = new FormData();
+      formData.append('photo', file);
+      try {
+        return await firstValueFrom(
+          this.http.post<any>(
+            `${environment.openAvatarApiUrl}/measurements`,
+            formData
+          )
+        );
+      } catch (err) {
+        console.error('Failed to fetch measurements from open-source API', err);
+        return { chest: 0, waist: 0, hip: 0 };
+      }
+    }
+
     if (
       !environment.bodyBlockApiKey ||
       environment.bodyBlockApiKey.includes('YOUR_BODYBLOCK_API_KEY')

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -4,6 +4,8 @@ export const environment = {
   removeBgApiKey: '',
   barcodeApiKey: '',
   bodyBlockApiKey: '',
+  // URL of the optional open-source avatar API for production builds
+  openAvatarApiUrl: '',
   firebase: {
     apiKey: "AIzaSyCJcut6NXAuJMCx_Ce7BH8GWuKbkZHyATw",
     authDomain: "ucloset3d.firebaseapp.com",

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,6 +4,10 @@ export const environment = {
   removeBgApiKey: 'YOUR_REMOVE_BG_API_KEY',
   barcodeApiKey: 'YOUR_BARCODE_API_KEY',
   bodyBlockApiKey: 'YOUR_BODYBLOCK_API_KEY',
+  // URL of the optional open-source avatar API. When provided the application
+  // will generate avatars and measurements locally instead of using paid
+  // services like Ready Player Me or BodyBlock.
+  openAvatarApiUrl: '',
   firebase: {
     apiKey: "AIzaSyCJcut6NXAuJMCx_Ce7BH8GWuKbkZHyATw",
     authDomain: "ucloset3d.firebaseapp.com",


### PR DESCRIPTION
## Summary
- add backend avatar service using Flask
- support optional open-source avatar API in environment configs
- use the new API in avatar and measurement services when configured
- document running the avatar API in README

## Testing
- `npx -y -p @angular/cli ng lint` *(fails: Cannot find "lint" target)*
- `npx -y -p @angular/cli ng test --watch=false` *(fails: could not find builder)*

------
https://chatgpt.com/codex/tasks/task_e_6857ecf151c4832eb767072baa42ea51