### PR TITLE
Convert outfits to inline data URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ The UI provides the following pages:
 6. **Motion Generator** – convert text prompts into animations.
 7. **Gallery Sharing** – publish completed looks to a shareable gallery page.
 
+## Default outfits
+
+Example outfit images are stored inline as base64 data URIs in
+`src/app/models/default-outfits.ts`. This avoids keeping `.png` files in
+`src/assets/outfits`.
+
 ## Development
 
 1. Install dependencies

--- a/src/app/models/default-outfits.ts
+++ b/src/app/models/default-outfits.ts
@@ -1,0 +1,19 @@
+import { ClosetItem } from './closet-item';
+
+/**
+ * Inline base64 images for default outfits to avoid binary files in the repo.
+ */
+export const defaultOutfits: ClosetItem[] = [
+  {
+    url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==',
+    category: 'Hat'
+  },
+  {
+    url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgaGD4DwAChAGA+gVWHQAAAABJRU5ErkJggg==',
+    category: 'Shirt'
+  },
+  {
+    url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYPj/HwADAgH/5ncLrgAAAABJRU5ErkJggg==',
+    category: 'Pants'
+  }
+];


### PR DESCRIPTION
## Summary
- add inline default outfit images and document them

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587b7ee0b8832e9fd6a419d18fd845