### PR TITLE
Enable PIFuHD-based avatar generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ firebase deploy
 ### Optional open-source avatar server
 
 The project can generate avatars locally using open-source tools. A small Flask
-server is provided in `backend/` as a starting point. It returns a demo avatar
-and sample measurements but can be extended with projects like
+server is provided in `backend/` that now runs the
+[PIFuHD](https://github.com/facebookresearch/pifuhd) pipeline to build a 3D
+model from a single photo. The server also returns mock measurements but can be
+extended with projects like
 [SMPL-Anthropometry](https://github.com/sergeyprokudin/smpl-anthropometry) or
 [3d-body-measurements](https://github.com/korrair/3d-body-measurements).
 
@@ -52,10 +54,11 @@ npm run start:avatar-api
 
 #### Digitizing an image into 3D
 
-The backend now includes a script `backend/digitize_avatar.py` that runs the
-[PIFuHD](https://github.com/facebookresearch/pifuhd) pipeline. An additional
-endpoint `/digitize-avatar` accepts an uploaded image and returns a reconstructed
-OBJ file. Running this requires PyTorch and may take several minutes on CPU.
+The backend uses the script `backend/digitize_avatar.py` to run the
+[PIFuHD](https://github.com/facebookresearch/pifuhd) pipeline. The
+`/generate-avatar` endpoint accepts an uploaded image and returns a reconstructed
+GLB file, while `/digitize-avatar` exposes the raw OBJ result. Running this
+requires PyTorch and may take several minutes on CPU.
 
 Then set `openAvatarApiUrl` in `src/environments/environment.ts` to the server
 URL, e.g. `http://localhost:5000`.

--- a/backend/avatar_api.py
+++ b/backend/avatar_api.py
@@ -3,6 +3,8 @@ from flask import Flask, request, send_file, jsonify
 import tempfile
 import subprocess
 import numpy as np
+import trimesh
+from .digitize_avatar import run_pifuhd
 
 app = Flask(__name__)
 
@@ -11,13 +13,34 @@ DEFAULT_AVATAR_PATH = os.path.join(os.path.dirname(__file__), '..', 'src', 'asse
 
 @app.route('/generate-avatar', methods=['POST'])
 def generate_avatar():
-    """Generate a 3D avatar from a user photo using open-source tools.
-    This implementation returns a demo avatar file but can be replaced with
-    SMPL-based generation.
-    """
-    if not os.path.exists(DEFAULT_AVATAR_PATH):
-        return 'Avatar asset missing', 500
-    return send_file(DEFAULT_AVATAR_PATH, mimetype='model/gltf-binary')
+    """Generate a 3D avatar from a user photo using PIFuHD."""
+    if 'photo' not in request.files:
+        return 'missing image', 400
+
+    photo = request.files['photo']
+    with tempfile.TemporaryDirectory() as tmpdir:
+        image_path = os.path.join(tmpdir, photo.filename)
+        photo.save(image_path)
+        output_dir = os.path.join(tmpdir, 'out')
+        os.makedirs(output_dir, exist_ok=True)
+        try:
+            run_pifuhd(image_path, output_dir)
+        except subprocess.CalledProcessError as e:
+            return f'Processing error: {e}', 500
+
+        for fname in os.listdir(output_dir):
+            if fname.endswith('.obj'):
+                obj_path = os.path.join(output_dir, fname)
+                mesh = trimesh.load(obj_path, process=False)
+                glb_data = trimesh.exchange.gltf.export_glb(mesh)
+                glb_path = os.path.join(output_dir, 'avatar.glb')
+                with open(glb_path, 'wb') as f:
+                    f.write(glb_data)
+                return send_file(glb_path, mimetype='model/gltf-binary')
+
+    if os.path.exists(DEFAULT_AVATAR_PATH):
+        return send_file(DEFAULT_AVATAR_PATH, mimetype='model/gltf-binary')
+    return 'Avatar asset missing', 500
 
 @app.route('/measurements', methods=['POST'])
 def measurements():


### PR DESCRIPTION
## Summary
- integrate PIFuHD into backend `generate-avatar` endpoint
- convert generated OBJ to GLB so the frontend viewer works
- document new server behaviour in README

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589c4dd460832e898c835ffd1832ee