### PR TITLE
Fix avatar generation and extend outfit categories

### DIFF
--- a/backend/digitize_avatar.py
+++ b/backend/digitize_avatar.py
@@ -16,14 +16,14 @@ def run_pifuhd(image_path: str, out_dir: str):
             'wget', 'https://dl.fbaipublicfiles.com/pifuhd/checkpoints/pifuhd.pt',
             '-O', ckpt
         ])
-    script = os.path.join(repo_dir, 'apps', 'eval.py')
+    script = os.path.join(repo_dir, 'apps', 'simple_test.py')
     subprocess.check_call([
         'python', script,
-        '--dataroot', image_path,
-        '--results_path', out_dir,
+        '--input_path', image_path,
+        '--output_path', out_dir,
         '--loadSize', '512',
         '--load_netMR_checkpoint_path', ckpt,
-        '--load_netG_checkpoint_path', ckpt
+        '--load_netG_checkpoint_path', ckpt,
     ])
 
 if __name__ == '__main__':

--- a/src/app/components/mix-match/mix-match.component.ts
+++ b/src/app/components/mix-match/mix-match.component.ts
@@ -6,5 +6,5 @@ import { Component } from '@angular/core';
   styleUrls: ['./mix-match.component.scss']
 })
 export class MixMatchComponent {
-  outfits: string[] = ['Hat', 'Shirt', 'Pants', 'Shoes'];
+  outfits: string[] = ['Hat', 'Top', 'Shirt', 'Pants', 'Skirt', 'Shoes'];
 }

--- a/src/app/components/upload-outfits/upload-outfits.component.ts
+++ b/src/app/components/upload-outfits/upload-outfits.component.ts
@@ -10,7 +10,7 @@ import { Router } from '@angular/router';
 })
 
 export class UploadOutfitsComponent {
-  categories = ['Hat', 'Shirt', 'Pants', 'Shoes'];
+  categories = ['Hat', 'Top', 'Shirt', 'Pants', 'Skirt', 'Shoes'];
   selectedCategory = this.categories[0];
   selectedFiles: File[] = [];
   uploadedUrls: string[] = [];


### PR DESCRIPTION
## Summary
- use simple_test.py script for generating avatars
- extend clothing categories to include tops and skirts

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589fe91be4832eab75d0f32e0f005e