### PR TITLE
Integrate barcode scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ export const environment = {
   production: false,
   readyPlayerMeApiKey: 'YOUR_READY_PLAYER_ME_API_KEY',
   removeBgApiKey: 'YOUR_REMOVE_BG_API_KEY',
-  barcodeApiKey: 'YOUR_BARCODE_API_KEY',
+  scanditLicenseKey: 'YOUR_SCANDIT_LICENSE_KEY',
   bodyBlockApiKey: 'YOUR_BODYBLOCK_API_KEY',
   openAvatarApiUrl: '',
   // Optional SayMotion REST API configuration

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -16,6 +16,7 @@ import { FashionChallengeComponent } from './components/fashion-challenge/fashio
 import { MotionGeneratorComponent } from './components/motion-generator/motion-generator.component';
 import { AnimateVideoComponent } from './components/animate-video/animate-video.component';
 import { MetahumanVideoComponent } from './components/metahuman-video/metahuman-video.component';
+import { BarcodeScanComponent } from './components/barcode-scan/barcode-scan.component';
 
 
 
@@ -35,6 +36,7 @@ const routes: Routes = [
   { path: 'outfit-gallery', component: OutfitGalleryComponent },
   { path: 'animate', component: AnimateVideoComponent },
   { path: 'metahuman-video', component: MetahumanVideoComponent },
+  { path: 'barcode-scan', component: BarcodeScanComponent },
   { path: 'challenge', component: FashionChallengeComponent },
   { path: 'motion-generator', component: MotionGeneratorComponent },
 //   { path: '**', redirectTo: 'upload' }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,6 +9,7 @@
     <a routerLink="/mix-match" routerLinkActive="active">Mix & Match</a>
     <a routerLink="/virtual-closet" routerLinkActive="active">Wardrobe</a>
       <a routerLink="/virtual-closet" routerLinkActive="active">Virtual Closet</a>
+    <a routerLink="/barcode-scan" routerLinkActive="active">Scan Barcode</a>
     <a routerLink="/challenge" routerLinkActive="active">Challenge</a>
     <a routerLink="/cart" routerLinkActive="active">Cart</a>
   <a routerLink="/profile" routerLinkActive="active">Profile</a>
@@ -23,6 +24,7 @@
       <a routerLink="/avatar" routerLinkActive="active">Avatar</a>
       <a routerLink="/mix-match" routerLinkActive="active">Mix & Match</a>
       <a routerLink="/animate" routerLinkActive="active">Animate</a>
+      <a routerLink="/barcode-scan" routerLinkActive="active">Scan</a>
       <a routerLink="/challenge" routerLinkActive="active">Challenge</a>
       <a routerLink="/gallery" routerLinkActive="active">Gallery</a>
     </nav>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { FashionChallengeComponent } from './components/fashion-challenge/fashio
 import { MotionGeneratorComponent } from './components/motion-generator/motion-generator.component';
 import { AnimateVideoComponent } from './components/animate-video/animate-video.component';
 import { MetahumanVideoComponent } from './components/metahuman-video/metahuman-video.component';
+import { BarcodeScanComponent } from './components/barcode-scan/barcode-scan.component';
 
 
 @NgModule({
@@ -45,6 +46,7 @@ import { MetahumanVideoComponent } from './components/metahuman-video/metahuman-
     MotionGeneratorComponent,
     AnimateVideoComponent,
     MetahumanVideoComponent,
+    BarcodeScanComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/barcode-scan/barcode-scan.component.html
+++ b/src/app/components/barcode-scan/barcode-scan.component.html
@@ -1,0 +1,6 @@
+<h2>Scan Barcode</h2>
+<input type="file" accept="image/*" (change)="onFileSelected($event)">
+<button (click)="scan()" [disabled]="loading || !selectedFile">Scan</button>
+<div *ngIf="loading">Scanning...</div>
+<div *ngIf="result">Result: {{ result }}</div>
+<div class="error" *ngIf="error">{{ error }}</div>

--- a/src/app/components/barcode-scan/barcode-scan.component.scss
+++ b/src/app/components/barcode-scan/barcode-scan.component.scss
@@ -1,0 +1,10 @@
+h2 {
+  margin-bottom: 1rem;
+}
+button {
+  margin-left: 0.5rem;
+}
+.error {
+  color: red;
+  margin-top: 0.5rem;
+}

--- a/src/app/components/barcode-scan/barcode-scan.component.ts
+++ b/src/app/components/barcode-scan/barcode-scan.component.ts
@@ -1,0 +1,38 @@
+import { Component } from '@angular/core';
+import { BarcodeService } from '../../services/barcode.service';
+
+@Component({
+  selector: 'app-barcode-scan',
+  templateUrl: './barcode-scan.component.html',
+  styleUrls: ['./barcode-scan.component.scss']
+})
+export class BarcodeScanComponent {
+  selectedFile?: File;
+  result?: string;
+  error?: string;
+  loading = false;
+
+  constructor(private barcodeService: BarcodeService) {}
+
+  onFileSelected(event: Event) {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files[0]) {
+      this.selectedFile = input.files[0];
+    }
+  }
+
+  async scan() {
+    if (!this.selectedFile) {
+      return;
+    }
+    this.loading = true;
+    this.error = undefined;
+    try {
+      this.result = await this.barcodeService.decodeBarcode(this.selectedFile);
+    } catch {
+      this.error = 'Failed to decode barcode.';
+    } finally {
+      this.loading = false;
+    }
+  }
+}

--- a/src/app/services/barcode.service.ts
+++ b/src/app/services/barcode.service.ts
@@ -12,7 +12,7 @@ export class BarcodeService {
     formData.append('image', image);
 
     const headers = new HttpHeaders({
-      Authorization: `Token ${environment.barcodeApiKey}`
+      Authorization: `Token ${environment.scanditLicenseKey}`
     });
 
     const response = await firstValueFrom(

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,7 +2,7 @@ export const environment = {
   production: true,
   readyPlayerMeApiKey: '',
   removeBgApiKey: '',
-  barcodeApiKey: '',
+  scanditLicenseKey: '',
   bodyBlockApiKey: '',
   // URL of the optional open-source avatar API for production builds
   openAvatarApiUrl: '',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -2,7 +2,7 @@ export const environment = {
   production: false,
   readyPlayerMeApiKey: 'YOUR_READY_PLAYER_ME_API_KEY',
   removeBgApiKey: 'YOUR_REMOVE_BG_API_KEY',
-  barcodeApiKey: 'YOUR_BARCODE_API_KEY',
+  scanditLicenseKey: 'YOUR_SCANDIT_LICENSE_KEY',
   bodyBlockApiKey: 'YOUR_BODYBLOCK_API_KEY',
   // URL of the optional open-source avatar API. When provided the application
   // will generate avatars and measurements locally instead of using paid


### PR DESCRIPTION
## Summary
- rename Scandit API key to `scanditLicenseKey`
- add a barcode scanning page using the Scandit API
- hook the page into routing and navigation
- document new variable in README

## Testing
- `npm run build`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6858a0d822ac832e931973b5e0b5e25f