### PR TITLE
Add Fashn.ai integration service

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ export const environment = {
   scanditLicenseKey: 'YOUR_SCANDIT_LICENSE_KEY',
   bodyBlockApiKey: 'YOUR_BODYBLOCK_API_KEY',
   openAvatarApiUrl: '',
+  // Fashn.ai virtual try-on configuration
+  fashnApiKey: 'YOUR_FASHN_API_KEY',
+  fashnApiUrl: 'https://api.fashn.ai/v1',
   // Optional SayMotion REST API configuration
   sayMotionBaseUrl: '',
   sayMotionClientId: '',
@@ -101,6 +104,21 @@ export const environment = {
     appId: 'YOUR_FIREBASE_APP_ID'
   }
 };
+```
+
+### Virtual try-on with Fashn.ai
+
+Add your Fashn API key and base URL to the environment configuration as shown above. The provided `FashnService` wraps the `/run` and `/status` endpoints and polls until the job completes.
+
+```ts
+import { FashnService } from './services/fashn.service';
+
+constructor(private fashn: FashnService) {}
+
+async preview() {
+  const result = await this.fashn.tryOn('model.jpg', 'garment.jpg', 'tops');
+  console.log(result);
+}
 ```
 
 Deploying to Firebase requires a valid Firebase project configuration. Ensure `firebase.json` has `"public": "dist/ucloset3d"` to match the Angular build output.

--- a/src/app/services/fashn.service.ts
+++ b/src/app/services/fashn.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class FashnService {
+  constructor(private http: HttpClient) {}
+
+  async tryOn(modelImage: string, garmentImage: string, category: string): Promise<any> {
+    const { fashnApiKey, fashnApiUrl } = environment;
+    if (!fashnApiKey || fashnApiKey.includes('YOUR_FASHN_API_KEY')) {
+      throw new Error('Fashn API key not configured');
+    }
+
+    const headers = new HttpHeaders({
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${fashnApiKey}`,
+    });
+
+    const runResp = await firstValueFrom(
+      this.http.post<{ id: string }>(`${fashnApiUrl}/run`,
+        { model_image: modelImage, garment_image: garmentImage, category },
+        { headers }
+      )
+    );
+
+    while (true) {
+      const status = await firstValueFrom(
+        this.http.get<any>(`${fashnApiUrl}/status/${runResp.id}`, { headers })
+      );
+      if (status.status === 'completed') {
+        return status.output;
+      } else if (['starting', 'in_queue', 'processing'].includes(status.status)) {
+        await new Promise(resolve => setTimeout(resolve, 3000));
+      } else {
+        throw new Error(status.error || 'Prediction failed');
+      }
+    }
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -6,6 +6,9 @@ export const environment = {
   bodyBlockApiKey: '',
   // URL of the optional open-source avatar API for production builds
   openAvatarApiUrl: '',
+  // Configuration for the Fashn.ai virtual try-on API
+  fashnApiKey: '',
+  fashnApiUrl: 'https://api.fashn.ai/v1',
   // Base URL and credentials for the optional SayMotion API integration
   sayMotionBaseUrl: '',
   sayMotionClientId: '',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -8,6 +8,9 @@ export const environment = {
   // will generate avatars and measurements locally instead of using paid
   // services like Ready Player Me or BodyBlock.
   openAvatarApiUrl: '',
+  // Configuration for the Fashn.ai virtual try-on API
+  fashnApiKey: 'YOUR_FASHN_API_KEY',
+  fashnApiUrl: 'https://api.fashn.ai/v1',
   // Base URL and credentials for the optional SayMotion API integration
   sayMotionBaseUrl: '',
   sayMotionClientId: '',


### PR DESCRIPTION
## Summary
- add `FashnService` that wraps Fashn.ai try‑on API
- update environments with Fashn API config
- document new config and usage in README

## Testing
- `npx ng test --browsers=ChromeHeadless --watch=false` *(fails: No binary for ChromeHeadless)*
- `npm run lint` *(fails: Cannot find "lint" target)*

------
https://chatgpt.com/codex/tasks/task_e_685a48269534832e91ff605ddbff542d