### PR TITLE
Enhance Fashn service options

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ export const environment = {
 
 ### Virtual try-on with Fashn.ai
 
-Add your Fashn API key and base URL to the environment configuration as shown above. The provided `FashnService` wraps the `/run` and `/status` endpoints and polls until the job completes.
+Add your Fashn API key and base URL to the environment configuration as shown above. The provided `FashnService` wraps the `/run` and `/status` endpoints and polls until the job completes. You may supply optional parameters such as `mode`, `garment_photo_type`, `num_samples` and `seed` via the final argument.
 
 ```ts
 import { FashnService } from './services/fashn.service';
@@ -116,7 +116,17 @@ import { FashnService } from './services/fashn.service';
 constructor(private fashn: FashnService) {}
 
 async preview() {
-  const result = await this.fashn.tryOn('model.jpg', 'garment.jpg', 'tops');
+  const result = await this.fashn.tryOn(
+    'model.jpg',
+    'garment.jpg',
+    'tops',
+    {
+      mode: 'standard',
+      garment_photo_type: 'flat',
+      num_samples: 3,
+      seed: 42,
+    }
+  );
   console.log(result);
 }
 ```

--- a/src/app/services/fashn.service.ts
+++ b/src/app/services/fashn.service.ts
@@ -3,11 +3,23 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { environment } from '../../environments/environment';
 
+export interface TryOnOptions {
+  /** Processing mode such as "standard" or "high_fidelity" */
+  mode?: string;
+  /** Type of garment photo, e.g. "flat" or "model" */
+  garment_photo_type?: string;
+  /** Number of samples the API should generate */
+  num_samples?: number;
+  /** Seed for deterministic output */
+  seed?: number;
+  [key: string]: any;
+}
+
 @Injectable({ providedIn: 'root' })
 export class FashnService {
   constructor(private http: HttpClient) {}
 
-  async tryOn(modelImage: string, garmentImage: string, category: string): Promise<any> {
+  async tryOn(modelImage: string, garmentImage: string, category: string, options: TryOnOptions = {}): Promise<any> {
     const { fashnApiKey, fashnApiUrl } = environment;
     if (!fashnApiKey || fashnApiKey.includes('YOUR_FASHN_API_KEY')) {
       throw new Error('Fashn API key not configured');
@@ -18,11 +30,15 @@ export class FashnService {
       Authorization: `Bearer ${fashnApiKey}`,
     });
 
+    const payload = {
+      model_image: modelImage,
+      garment_image: garmentImage,
+      category,
+      ...options,
+    };
+
     const runResp = await firstValueFrom(
-      this.http.post<{ id: string }>(`${fashnApiUrl}/run`,
-        { model_image: modelImage, garment_image: garmentImage, category },
-        { headers }
-      )
+      this.http.post<{ id: string }>(`${fashnApiUrl}/run`, payload, { headers })
     );
 
     while (true) {


### PR DESCRIPTION
## Summary
- allow passing additional parameters to `tryOn`
- document new Fashn.ai options in README

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a4c90c1ac832ea2e1a29f3c44c654