### PR TITLE
Add FASHN.ai virtual try-on feature

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -17,6 +17,7 @@ import { MotionGeneratorComponent } from './components/motion-generator/motion-g
 import { AnimateVideoComponent } from './components/animate-video/animate-video.component';
 import { MetahumanVideoComponent } from './components/metahuman-video/metahuman-video.component';
 import { BarcodeScanComponent } from './components/barcode-scan/barcode-scan.component';
+import { FashnTryOnComponent } from './components/fashn-try-on/fashn-try-on.component';
 
 
 
@@ -38,6 +39,7 @@ const routes: Routes = [
   { path: 'metahuman-video', component: MetahumanVideoComponent },
   { path: 'barcode-scan', component: BarcodeScanComponent },
   { path: 'challenge', component: FashionChallengeComponent },
+  { path: 'try-on', component: FashnTryOnComponent },
   { path: 'motion-generator', component: MotionGeneratorComponent },
 //   { path: '**', redirectTo: 'upload' }
   { path: '**', redirectTo: 'login' }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -24,6 +24,7 @@ import { MotionGeneratorComponent } from './components/motion-generator/motion-g
 import { AnimateVideoComponent } from './components/animate-video/animate-video.component';
 import { MetahumanVideoComponent } from './components/metahuman-video/metahuman-video.component';
 import { BarcodeScanComponent } from './components/barcode-scan/barcode-scan.component';
+import { FashnTryOnComponent } from './components/fashn-try-on/fashn-try-on.component';
 
 
 @NgModule({
@@ -47,6 +48,7 @@ import { BarcodeScanComponent } from './components/barcode-scan/barcode-scan.com
     AnimateVideoComponent,
     MetahumanVideoComponent,
     BarcodeScanComponent,
+    FashnTryOnComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/fashn-try-on/fashn-try-on.component.html
+++ b/src/app/components/fashn-try-on/fashn-try-on.component.html
@@ -1,0 +1,12 @@
+<div class="try-on-form">
+  <input type="file" (change)="onFileSelected($event, 'person')" />
+  <input type="file" (change)="onFileSelected($event, 'garment')" />
+  <button (click)="tryOnClothing()" [disabled]="loading">Try On This Look</button>
+  <div class="loading" *ngIf="loading">Processing...</div>
+  <div class="error" *ngIf="error">{{ error }}</div>
+</div>
+
+<img *ngIf="tryOnResult" [src]="tryOnResult" alt="Try-On Result" />
+<a *ngIf="tryOnResult" [href]="'https://www.instagram.com/sharing-url?image=' + tryOnResult" target="_blank">
+  Share on Instagram
+</a>

--- a/src/app/components/fashn-try-on/fashn-try-on.component.html
+++ b/src/app/components/fashn-try-on/fashn-try-on.component.html
@@ -1,12 +1,23 @@
 <div class="try-on-form">
-  <input type="file" (change)="onFileSelected($event, 'person')" />
-  <input type="file" (change)="onFileSelected($event, 'garment')" />
+  <label>
+    Model Image
+    <input type="file" (change)="onFileSelected($event, 'person')" />
+  </label>
+  <label>
+    Garment Image
+    <input type="file" (change)="onFileSelected($event, 'garment')" />
+  </label>
   <button (click)="tryOnClothing()" [disabled]="loading">Try On This Look</button>
   <div class="loading" *ngIf="loading">Processing...</div>
   <div class="error" *ngIf="error">{{ error }}</div>
 </div>
 
+<div class="preview" *ngIf="personPreview || garmentPreview">
+  <img *ngIf="personPreview" [src]="personPreview" alt="Person" />
+  <img *ngIf="garmentPreview" [src]="garmentPreview" alt="Garment" />
+</div>
+
 <img *ngIf="tryOnResult" [src]="tryOnResult" alt="Try-On Result" />
-<a *ngIf="tryOnResult" [href]="'https://www.instagram.com/sharing-url?image=' + tryOnResult" target="_blank">
-  Share on Instagram
-</a>
+<a *ngIf="tryOnResult" [href]="'https://www.instagram.com/sharing-url?image=' + tryOnResult" target="_blank">Share on Instagram</a>
+<button *ngIf="tryOnResult" (click)="next()">Next</button>
+

--- a/src/app/components/fashn-try-on/fashn-try-on.component.scss
+++ b/src/app/components/fashn-try-on/fashn-try-on.component.scss
@@ -1,0 +1,14 @@
+.try-on-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 1rem;
+}
+
+.loading {
+  color: blue;
+}
+
+.error {
+  color: red;
+}

--- a/src/app/components/fashn-try-on/fashn-try-on.component.scss
+++ b/src/app/components/fashn-try-on/fashn-try-on.component.scss
@@ -12,3 +12,9 @@
 .error {
   color: red;
 }
+
+.preview img {
+  max-width: 100px;
+  margin-right: 10px;
+}
+

--- a/src/app/components/fashn-try-on/fashn-try-on.component.ts
+++ b/src/app/components/fashn-try-on/fashn-try-on.component.ts
@@ -1,0 +1,58 @@
+import { Component } from '@angular/core';
+import { FashnService } from '../../services/fashn.service';
+import { FirebaseService } from '../../services/firebase.service';
+
+@Component({
+  selector: 'app-fashn-try-on',
+  templateUrl: './fashn-try-on.component.html',
+  styleUrls: ['./fashn-try-on.component.scss']
+})
+export class FashnTryOnComponent {
+  personImage?: File;
+  garmentImage?: File;
+  tryOnResult?: string;
+  loading = false;
+  error?: string;
+
+  constructor(
+    private fashn: FashnService,
+    private firestore: FirebaseService
+  ) {}
+
+  onFileSelected(event: any, type: 'person' | 'garment') {
+    const file = event.target.files && event.target.files[0];
+    if (!file) return;
+    if (type === 'person') {
+      this.personImage = file;
+    } else {
+      this.garmentImage = file;
+    }
+  }
+
+  async tryOnClothing() {
+    if (!this.personImage || !this.garmentImage) {
+      this.error = 'Please select both images.';
+      return;
+    }
+    this.error = undefined;
+    this.loading = true;
+    try {
+      const res = await this.fashn.tryOnFiles(
+        this.personImage,
+        this.garmentImage,
+        'tops'
+      );
+      this.tryOnResult = res.output_image_url || res.output;
+      // Optional: save result
+      await this.firestore.saveLook({
+        userId: 'demo',
+        lookImage: this.tryOnResult,
+        timestamp: new Date()
+      });
+    } catch {
+      this.error = 'Try-on failed.';
+    } finally {
+      this.loading = false;
+    }
+  }
+}

--- a/src/app/components/fashn-try-on/fashn-try-on.component.ts
+++ b/src/app/components/fashn-try-on/fashn-try-on.component.ts
@@ -1,31 +1,47 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { FashnService } from '../../services/fashn.service';
 import { FirebaseService } from '../../services/firebase.service';
+import { PersonImageService } from '../../services/person-image.service';
 
 @Component({
   selector: 'app-fashn-try-on',
   templateUrl: './fashn-try-on.component.html',
   styleUrls: ['./fashn-try-on.component.scss']
 })
-export class FashnTryOnComponent {
+export class FashnTryOnComponent implements OnInit {
   personImage?: File;
   garmentImage?: File;
+  personPreview?: string;
+  garmentPreview?: string;
   tryOnResult?: string;
   loading = false;
   error?: string;
 
   constructor(
     private fashn: FashnService,
-    private firestore: FirebaseService
+    private firestore: FirebaseService,
+    private personImageSvc: PersonImageService,
+    private router: Router
   ) {}
+
+  ngOnInit(): void {
+    const file = this.personImageSvc.getImage();
+    if (file) {
+      this.personImage = file;
+      this.personPreview = URL.createObjectURL(file);
+    }
+  }
 
   onFileSelected(event: any, type: 'person' | 'garment') {
     const file = event.target.files && event.target.files[0];
     if (!file) return;
     if (type === 'person') {
       this.personImage = file;
+      this.personPreview = URL.createObjectURL(file);
     } else {
       this.garmentImage = file;
+      this.garmentPreview = URL.createObjectURL(file);
     }
   }
 
@@ -54,5 +70,9 @@ export class FashnTryOnComponent {
     } finally {
       this.loading = false;
     }
+  }
+
+  next(): void {
+    this.router.navigate(['/virtual-closet']);
   }
 }

--- a/src/app/components/gallery/gallery.component.html
+++ b/src/app/components/gallery/gallery.component.html
@@ -1,1 +1,11 @@
-<p>Gallery works!</p>
+<div class="gallery" *ngIf="looks.length; else empty">
+  <div class="card" *ngFor="let look of looks">
+    <img [src]="look.lookImage" alt="Look" />
+    <button (click)="share(look)">Share</button>
+  </div>
+</div>
+<ng-template #empty>
+  <p>No looks saved.</p>
+</ng-template>
+<div class="error" *ngIf="error">{{ error }}</div>
+

--- a/src/app/components/gallery/gallery.component.scss
+++ b/src/app/components/gallery/gallery.component.scss
@@ -1,1 +1,19 @@
-/* Gallery component styles */
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 10px;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.card img {
+  width: 100%;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-bottom: 5px;
+}
+

--- a/src/app/components/gallery/gallery.component.ts
+++ b/src/app/components/gallery/gallery.component.ts
@@ -1,8 +1,37 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { FirebaseService } from '../../services/firebase.service';
+
+interface Look {
+  id: string;
+  lookImage: string;
+}
 
 @Component({
   selector: 'app-gallery',
   templateUrl: './gallery.component.html',
   styleUrls: ['./gallery.component.scss']
 })
-export class GalleryComponent {}
+export class GalleryComponent implements OnInit {
+  looks: Look[] = [];
+  error?: string;
+
+  constructor(private firebaseService: FirebaseService) {}
+
+  ngOnInit(): void {
+    this.loadLooks();
+  }
+
+  async loadLooks(): Promise<void> {
+    try {
+      this.error = undefined;
+      this.looks = await this.firebaseService.getSavedLooks();
+    } catch {
+      this.error = 'Failed to load looks.';
+    }
+  }
+
+  share(look: Look): void {
+    const url = encodeURIComponent(look.lookImage);
+    window.open(`https://www.instagram.com/?url=${url}`, '_blank');
+  }
+}

--- a/src/app/components/upload-outfits/upload-outfits.component.ts
+++ b/src/app/components/upload-outfits/upload-outfits.component.ts
@@ -66,7 +66,7 @@ export class UploadOutfitsComponent {
     }
     this.isUploading = false;
     if (!this.error) {
-      this.router.navigate(['/virtual-closet']);
+      this.router.navigate(['/try-on']);
     }
   }
 }

--- a/src/app/components/upload-photo/upload-photo.component.ts
+++ b/src/app/components/upload-photo/upload-photo.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { RemoveBgService } from '../../services/removebg.service';
 import { AvatarService } from '../../services/avatar.service';
 import { BodyBlockService } from '../../services/bodyblock.service';
+import { PersonImageService } from '../../services/person-image.service';
 
 @Component({
   selector: 'app-upload-photo',
@@ -24,6 +25,7 @@ export class UploadPhotoComponent {
     private avatarService: AvatarService,
     private removeBgService: RemoveBgService,
     private bodyBlockService: BodyBlockService,
+    private personImage: PersonImageService,
     private router: Router
   ) {}
 
@@ -36,6 +38,7 @@ export class UploadPhotoComponent {
     const files = event.dataTransfer?.files;
     if (files && files.length) {
       this.selectedFile = files[0];
+      this.personImage.setImage(this.selectedFile);
     }
   }
 
@@ -44,6 +47,7 @@ export class UploadPhotoComponent {
     const file = element.files && element.files[0];
     if (file) {
       this.selectedFile = file;
+      this.personImage.setImage(file);
     }
   }
 

--- a/src/app/services/fashn.service.ts
+++ b/src/app/services/fashn.service.ts
@@ -19,6 +19,36 @@ export interface TryOnOptions {
 export class FashnService {
   constructor(private http: HttpClient) {}
 
+  /**
+   * Upload raw image files to the Fashn API for virtual try-on.
+   * Returns the API response which typically includes an output_image_url.
+   */
+  async tryOnFiles(
+    modelFile: File,
+    garmentFile: File,
+    category: string,
+    options: Record<string, any> = {}
+  ): Promise<any> {
+    const { fashnApiKey, fashnApiUrl } = environment;
+    if (!fashnApiKey || fashnApiKey.includes('YOUR_FASHN_API_KEY')) {
+      throw new Error('Fashn API key not configured');
+    }
+
+    const headers = new HttpHeaders({
+      Authorization: `Bearer ${fashnApiKey}`,
+    });
+
+    const formData = new FormData();
+    formData.append('model_image', modelFile);
+    formData.append('garment_image', garmentFile);
+    formData.append('category', category);
+    Object.entries(options).forEach(([k, v]) => formData.append(k, v as any));
+
+    return firstValueFrom(
+      this.http.post<any>(`${fashnApiUrl}/run`, formData, { headers })
+    );
+  }
+
   async tryOn(modelImage: string, garmentImage: string, category: string, options: TryOnOptions = {}): Promise<any> {
     const { fashnApiKey, fashnApiUrl } = environment;
     if (!fashnApiKey || fashnApiKey.includes('YOUR_FASHN_API_KEY')) {

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -24,4 +24,8 @@ export class FirebaseService {
     const snapshot = await getDocs(collection(this.db, 'outfits'));
     return snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
   }
+
+  async saveLook(data: any): Promise<void> {
+    await addDoc(collection(this.db, 'savedLooks'), data);
+  }
 }

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -28,4 +28,10 @@ export class FirebaseService {
   async saveLook(data: any): Promise<void> {
     await addDoc(collection(this.db, 'savedLooks'), data);
   }
+
+  async getSavedLooks(): Promise<any[]> {
+    const snapshot = await getDocs(collection(this.db, 'savedLooks'));
+    return snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
+  }
 }
+

--- a/src/app/services/person-image.service.ts
+++ b/src/app/services/person-image.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+@Injectable({ providedIn: 'root' })
+export class PersonImageService {
+  private file?: File;
+  setImage(file: File) { this.file = file; }
+  getImage(): File | undefined { return this.file; }
+}
+


### PR DESCRIPTION
## Summary
- integrate new FashnTryOnComponent for uploading person and garment images
- add service method for uploading files to Fashn API
- extend FirebaseService to store try-on results
- register new component and route in Angular app

## Testing
- `npm install`
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_685a50230250832ebad69bff44d53c4b