### PR TITLE
Add mix-match outfit generator service

### DIFF
--- a/src/app/components/mix-match/mix-match.component.html
+++ b/src/app/components/mix-match/mix-match.component.html
@@ -1,6 +1,10 @@
-<ul *ngIf="outfits.length; else empty">
-  <li *ngFor="let item of outfits">{{ item }}</li>
-</ul>
+<button (click)="generate()" [disabled]="loading">Generate</button>
+<p *ngIf="error" class="error">{{ error }}</p>
+<div *ngFor="let outfit of combinations" class="outfit">
+  <div *ngFor="let item of outfit" class="piece">
+    <img [src]="item.url" [alt]="item.category" />
+  </div>
+</div>
 <ng-template #empty>
   <p>No outfits available.</p>
 </ng-template>

--- a/src/app/components/mix-match/mix-match.component.scss
+++ b/src/app/components/mix-match/mix-match.component.scss
@@ -1,12 +1,16 @@
-ul { list-style: none; padding: 0; }
-li {
-  padding: 0.25rem 0;
-  background: #f0f0f0;
-  margin-bottom: 0.25rem;
-  text-align: center;
+.outfit {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
 }
-
-p {
+.piece {
+  margin: 0 0.25rem;
+}
+img {
+  max-width: 60px;
+  height: auto;
+}
+.error {
+  color: red;
   text-align: center;
-  color: #666;
 }

--- a/src/app/components/mix-match/mix-match.component.ts
+++ b/src/app/components/mix-match/mix-match.component.ts
@@ -1,10 +1,32 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { MixMatchService } from '../../services/mix-match.service';
+import { ClosetItem } from '../../models/closet-item';
 
 @Component({
   selector: 'app-mix-match',
   templateUrl: './mix-match.component.html',
   styleUrls: ['./mix-match.component.scss']
 })
-export class MixMatchComponent {
-  outfits: string[] = ['Hat', 'Top', 'Shirt', 'Pants', 'Skirt', 'Shoes'];
+export class MixMatchComponent implements OnInit {
+  combinations: ClosetItem[][] = [];
+  loading = false;
+  error?: string;
+
+  constructor(private mixMatchService: MixMatchService) {}
+
+  ngOnInit(): void {
+    this.generate();
+  }
+
+  async generate(): Promise<void> {
+    this.loading = true;
+    this.error = undefined;
+    try {
+      this.combinations = await this.mixMatchService.generateOutfits(5);
+    } catch {
+      this.error = 'Failed to generate outfits.';
+    } finally {
+      this.loading = false;
+    }
+  }
 }

--- a/src/app/services/mix-match.service.ts
+++ b/src/app/services/mix-match.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { FirebaseService } from './firebase.service';
+import { ClosetItem } from '../models/closet-item';
+import { DEFAULT_OUTFITS } from '../models/default-outfits';
+
+@Injectable({ providedIn: 'root' })
+export class MixMatchService {
+  constructor(private firebaseService: FirebaseService) {}
+
+  private groupByCategory(items: ClosetItem[]): Record<string, ClosetItem[]> {
+    const grouped: Record<string, ClosetItem[]> = {};
+    for (const item of items) {
+      const cat = item.category || 'misc';
+      if (!grouped[cat]) {
+        grouped[cat] = [];
+      }
+      grouped[cat].push(item);
+    }
+    return grouped;
+  }
+
+  private cartesian(arrays: ClosetItem[][]): ClosetItem[][] {
+    return arrays.reduce<ClosetItem[][]>((acc, curr) => {
+      const result: ClosetItem[][] = [];
+      for (const a of acc) {
+        for (const b of curr) {
+          result.push([...a, b]);
+        }
+      }
+      return result;
+    }, [[]]);
+  }
+
+  async generateOutfits(max = 10): Promise<ClosetItem[][]> {
+    const items = await this.firebaseService.getOutfits();
+    const source = items.length ? items.map(o => ({ url: o.imageUrl, category: o.category })) : DEFAULT_OUTFITS;
+    const grouped = this.groupByCategory(source);
+    const combos = this.cartesian(Object.values(grouped));
+    return combos.slice(0, max);
+  }
+}


### PR DESCRIPTION
## Summary
- generate outfit combinations in Mix & Match page
- display generated outfits with images
- style mix & match combinations

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a63f4075c832e9783d522fce47986