### PR TITLE
Add Awesome VTON integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ export const environment = {
   // Fashn.ai virtual try-on configuration
   fashnApiKey: 'YOUR_FASHN_API_KEY',
   fashnApiUrl: 'https://api.fashn.ai/v1',
+  // Optional Awesome-VTON server for mix & match
+  awesomeVtonApiUrl: '',
   // Optional SayMotion REST API configuration
   sayMotionBaseUrl: '',
   sayMotionClientId: '',
@@ -128,6 +130,21 @@ async preview() {
     }
   );
   console.log(result);
+}
+```
+
+### Mix & Match with Awesome VTON
+
+This project can call the [DOC-VTON](https://github.com/JyChen9811/DOC-VTON) implementation of "Awesome Virtual Try-On." Run the server from that repository separately and set `awesomeVtonApiUrl` in `src/environments/environment.ts` to its base URL.
+
+```ts
+import { AwesomeVtonService } from './services/awesome-vton.service';
+
+constructor(private awesome: AwesomeVtonService) {}
+
+async generate() {
+  const url = await this.awesome.tryOnFiles(modelFile, garmentFile, 'tops');
+  console.log(url);
 }
 ```
 

--- a/src/app/components/mix-match/mix-match.component.html
+++ b/src/app/components/mix-match/mix-match.component.html
@@ -1,6 +1,14 @@
-<ul *ngIf="outfits.length; else empty">
-  <li *ngFor="let item of outfits">{{ item }}</li>
-</ul>
-<ng-template #empty>
-  <p>No outfits available.</p>
-</ng-template>
+<div class="uploader">
+  <label>
+    Model image
+    <input type="file" (change)="onFileSelected($event, 'model')" />
+  </label>
+  <label>
+    Garment image
+    <input type="file" (change)="onFileSelected($event, 'garment')" />
+  </label>
+  <button (click)="tryOn()" [disabled]="loading">Try On</button>
+</div>
+
+<div *ngIf="error" class="error">{{ error }}</div>
+<img *ngIf="resultUrl" [src]="resultUrl" alt="Result" />

--- a/src/app/components/mix-match/mix-match.component.scss
+++ b/src/app/components/mix-match/mix-match.component.scss
@@ -10,3 +10,14 @@ p {
   text-align: center;
   color: #666;
 }
+
+.uploader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.error {
+  color: red;
+}

--- a/src/app/components/mix-match/mix-match.component.ts
+++ b/src/app/components/mix-match/mix-match.component.ts
@@ -1,4 +1,10 @@
 import { Component } from '@angular/core';
+import { AwesomeVtonService } from '../../services/awesome-vton.service';
+
+interface FileSelection {
+  file?: File;
+  preview?: string;
+}
 
 @Component({
   selector: 'app-mix-match',
@@ -7,4 +13,42 @@ import { Component } from '@angular/core';
 })
 export class MixMatchComponent {
   outfits: string[] = ['Hat', 'Top', 'Shirt', 'Pants', 'Skirt', 'Shoes'];
+  model: FileSelection = {};
+  garment: FileSelection = {};
+  resultUrl?: string;
+  loading = false;
+  error?: string;
+
+  constructor(private awesome: AwesomeVtonService) {}
+
+  onFileSelected(event: any, type: 'model' | 'garment') {
+    const file = event.target.files && event.target.files[0];
+    if (!file) return;
+    const preview = URL.createObjectURL(file);
+    if (type === 'model') {
+      this.model = { file, preview };
+    } else {
+      this.garment = { file, preview };
+    }
+  }
+
+  async tryOn() {
+    if (!this.model.file || !this.garment.file) {
+      this.error = 'Please select both images.';
+      return;
+    }
+    this.loading = true;
+    this.error = undefined;
+    try {
+      this.resultUrl = await this.awesome.tryOnFiles(
+        this.model.file,
+        this.garment.file,
+        'tops'
+      );
+    } catch {
+      this.error = 'Try-on failed.';
+    } finally {
+      this.loading = false;
+    }
+  }
 }

--- a/src/app/services/awesome-vton.service.ts
+++ b/src/app/services/awesome-vton.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class AwesomeVtonService {
+  constructor(private http: HttpClient) {}
+
+  async tryOnFiles(model: File, garment: File, category = 'tops'): Promise<string> {
+    if (!environment.awesomeVtonApiUrl) {
+      throw new Error('Awesome VTON API not configured');
+    }
+    const formData = new FormData();
+    formData.append('model', model);
+    formData.append('garment', garment);
+    formData.append('category', category);
+    const resp = await firstValueFrom(
+      this.http.post<{ output_url: string }>(`${environment.awesomeVtonApiUrl}/tryon`, formData)
+    );
+    return resp.output_url;
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -9,6 +9,8 @@ export const environment = {
   // Configuration for the Fashn.ai virtual try-on API
   fashnApiKey: '',
   fashnApiUrl: 'https://api.fashn.ai/v1',
+  // Base URL for the Awesome Virtual Try-On server
+  awesomeVtonApiUrl: '',
   // Base URL and credentials for the optional SayMotion API integration
   sayMotionBaseUrl: '',
   sayMotionClientId: '',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -11,6 +11,8 @@ export const environment = {
   // Configuration for the Fashn.ai virtual try-on API
   fashnApiKey: 'YOUR_FASHN_API_KEY',
   fashnApiUrl: 'https://api.fashn.ai/v1',
+  // Base URL for the Awesome Virtual Try-On server
+  awesomeVtonApiUrl: '',
   // Base URL and credentials for the optional SayMotion API integration
   sayMotionBaseUrl: '',
   sayMotionClientId: '',


### PR DESCRIPTION
## Summary
- add `AwesomeVtonService` for calling an external virtual try-on server
- expose `awesomeVtonApiUrl` in environment configs
- update Mix & Match component to call the service
- document how to configure and use Awesome VTON

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6206faf8832ebac465b0280302b3