### PR TITLE
Integrate Fashion Deck wardrobe model

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ Example outfit images are stored inline as base64 data URIs in
 `src/app/models/default-outfits.ts`. This avoids keeping `.png` files in
 `src/assets/outfits`.
 
+## Wardrobe model
+
+The application now includes a simple wardrobe service inspired by the
+[Fashion Deck](https://github.com/TheMisterPin/fashion-deck) project. Core
+clothing enums like `ClothingType` and `Color` are defined in
+`src/app/models/fashion.models.ts` and can be used throughout the app for
+consistent wardrobe data.
+
 ## Development
 
 1. Install dependencies

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -18,6 +18,7 @@ import { AnimateVideoComponent } from './components/animate-video/animate-video.
 import { MetahumanVideoComponent } from './components/metahuman-video/metahuman-video.component';
 import { BarcodeScanComponent } from './components/barcode-scan/barcode-scan.component';
 import { FashnTryOnComponent } from './components/fashn-try-on/fashn-try-on.component';
+import { WardrobeComponent } from './components/wardrobe/wardrobe.component';
 
 
 
@@ -35,6 +36,7 @@ const routes: Routes = [
   { path: 'cart', component: CartComponent },
   { path: 'profile', component: ProfileComponent },
   { path: 'outfit-gallery', component: OutfitGalleryComponent },
+  { path: 'wardrobe', component: WardrobeComponent },
   { path: 'animate', component: AnimateVideoComponent },
   { path: 'metahuman-video', component: MetahumanVideoComponent },
   { path: 'barcode-scan', component: BarcodeScanComponent },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { AnimateVideoComponent } from './components/animate-video/animate-video.
 import { MetahumanVideoComponent } from './components/metahuman-video/metahuman-video.component';
 import { BarcodeScanComponent } from './components/barcode-scan/barcode-scan.component';
 import { FashnTryOnComponent } from './components/fashn-try-on/fashn-try-on.component';
+import { WardrobeComponent } from './components/wardrobe/wardrobe.component';
 
 
 @NgModule({
@@ -49,6 +50,7 @@ import { FashnTryOnComponent } from './components/fashn-try-on/fashn-try-on.comp
     MetahumanVideoComponent,
     BarcodeScanComponent,
     FashnTryOnComponent,
+    WardrobeComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/upload-outfits/upload-outfits.component.ts
+++ b/src/app/components/upload-outfits/upload-outfits.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { ClothingType } from '../../models/fashion.models';
 import { RemoveBgService } from '../../services/removebg.service';
 import { FirebaseService } from '../../services/firebase.service';
 import { Router } from '@angular/router';
@@ -10,7 +11,7 @@ import { Router } from '@angular/router';
 })
 
 export class UploadOutfitsComponent {
-  categories = ['Hat', 'Top', 'Shirt', 'Pants', 'Skirt', 'Shoes'];
+  categories = Object.values(ClothingType);
   selectedCategory = this.categories[0];
   selectedFiles: File[] = [];
   uploadedUrls: string[] = [];

--- a/src/app/components/wardrobe/wardrobe.component.html
+++ b/src/app/components/wardrobe/wardrobe.component.html
@@ -1,0 +1,10 @@
+<div class="wardrobe">
+  <h2>Your Wardrobe</h2>
+  <div *ngIf="!items.length">No items added yet.</div>
+  <ul>
+    <li *ngFor="let item of items">
+      <img *ngIf="item.picture" [src]="item.picture" alt="item" />
+      <span>{{ item.type }} - {{ item.color }}</span>
+    </li>
+  </ul>
+</div>

--- a/src/app/components/wardrobe/wardrobe.component.scss
+++ b/src/app/components/wardrobe/wardrobe.component.scss
@@ -1,0 +1,19 @@
+.wardrobe {
+  h2 {
+    margin-bottom: 1rem;
+  }
+  ul {
+    list-style: none;
+    padding: 0;
+  }
+  li {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.5rem;
+    img {
+      height: 40px;
+      width: 40px;
+      margin-right: 0.5rem;
+    }
+  }
+}

--- a/src/app/components/wardrobe/wardrobe.component.ts
+++ b/src/app/components/wardrobe/wardrobe.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+import { WardrobeService } from '../../services/wardrobe.service';
+import { ClothingItem } from '../../models/fashion.models';
+
+@Component({
+  selector: 'app-wardrobe',
+  templateUrl: './wardrobe.component.html',
+  styleUrls: ['./wardrobe.component.scss']
+})
+export class WardrobeComponent implements OnInit {
+  items: ClothingItem[] = [];
+
+  constructor(private wardrobe: WardrobeService) {}
+
+  ngOnInit(): void {
+    this.items = this.wardrobe.getItems();
+  }
+}

--- a/src/app/models/fashion.models.ts
+++ b/src/app/models/fashion.models.ts
@@ -1,0 +1,41 @@
+export enum ClothingType {
+  SHIRT = 'SHIRT',
+  PANTS = 'PANTS',
+  JACKET = 'JACKET',
+  JUMPER = 'JUMPER',
+  SHOES = 'SHOES',
+  HOODIE = 'HOODIE'
+}
+
+export enum Occasion {
+  CASUAL = 'CASUAL',
+  WORK = 'WORK',
+  SPORT = 'SPORT',
+  FORMAL = 'FORMAL'
+}
+
+export enum Color {
+  RED = 'RED',
+  BLUE = 'BLUE',
+  BROWN = 'BROWN',
+  PINK = 'PINK',
+  GREY = 'GREY',
+  BEIGE = 'BEIGE',
+  GREEN = 'GREEN',
+  BLACK = 'BLACK',
+  WHITE = 'WHITE',
+  YELLOW = 'YELLOW'
+}
+
+export interface ClothingItem {
+  id?: number;
+  type: ClothingType;
+  name?: string | null;
+  color?: Color | null;
+  picture?: string | null;
+  timesWorn?: number;
+  lastWorn?: Date | null;
+  isFavorite?: boolean;
+  isAvailable?: boolean;
+  description?: string | null;
+}

--- a/src/app/services/wardrobe.service.ts
+++ b/src/app/services/wardrobe.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { ClothingItem, ClothingType, Color, Occasion } from '../models/fashion.models';
+
+@Injectable({ providedIn: 'root' })
+export class WardrobeService {
+  private storageKey = 'wardrobe-items';
+
+  private load(): ClothingItem[] {
+    const data = localStorage.getItem(this.storageKey);
+    return data ? JSON.parse(data) : [];
+  }
+
+  private save(items: ClothingItem[]) {
+    localStorage.setItem(this.storageKey, JSON.stringify(items));
+  }
+
+  getItems(): ClothingItem[] {
+    return this.load();
+  }
+
+  addItem(item: ClothingItem): void {
+    const items = this.load();
+    item.id = Date.now();
+    items.push(item);
+    this.save(items);
+  }
+
+  removeItem(id: number): void {
+    const items = this.load().filter(i => i.id !== id);
+    this.save(items);
+  }
+}


### PR DESCRIPTION
## Summary
- add fashion-related enums and `ClothingItem` model
- implement `WardrobeService` for managing clothing items
- update upload component to use new enums
- add wardrobe component and route
- document new wardrobe model in README

## Testing
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6f6d1678832eb825c44ee289d21a