### PR TITLE
Add 2D dress up component

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -18,6 +18,7 @@ import { AnimateVideoComponent } from './components/animate-video/animate-video.
 import { MetahumanVideoComponent } from './components/metahuman-video/metahuman-video.component';
 import { BarcodeScanComponent } from './components/barcode-scan/barcode-scan.component';
 import { FashnTryOnComponent } from './components/fashn-try-on/fashn-try-on.component';
+import { ModelDressUpComponent } from './components/model-dress-up/model-dress-up.component';
 
 
 
@@ -40,6 +41,7 @@ const routes: Routes = [
   { path: 'barcode-scan', component: BarcodeScanComponent },
   { path: 'challenge', component: FashionChallengeComponent },
   { path: 'try-on', component: FashnTryOnComponent },
+  { path: 'dress-up', component: ModelDressUpComponent },
   { path: 'motion-generator', component: MotionGeneratorComponent },
 //   { path: '**', redirectTo: 'upload' }
   { path: '**', redirectTo: 'login' }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,6 +7,7 @@
     <a routerLink="/animate" routerLinkActive="active">Animate Video</a>
     <a routerLink="/upload-outfits" routerLinkActive="active">Upload Outfits</a>
     <a routerLink="/mix-match" routerLinkActive="active">Mix & Match</a>
+    <a routerLink="/dress-up" routerLinkActive="active">Dress Up</a>
     <a routerLink="/virtual-closet" routerLinkActive="active">Wardrobe</a>
       <a routerLink="/virtual-closet" routerLinkActive="active">Virtual Closet</a>
     <a routerLink="/barcode-scan" routerLinkActive="active">Scan Barcode</a>
@@ -23,6 +24,7 @@
         <a routerLink="/upload-photo" routerLinkActive="active">Upload</a>
       <a routerLink="/avatar" routerLinkActive="active">Avatar</a>
       <a routerLink="/mix-match" routerLinkActive="active">Mix & Match</a>
+      <a routerLink="/dress-up" routerLinkActive="active">Dress Up</a>
       <a routerLink="/animate" routerLinkActive="active">Animate</a>
       <a routerLink="/barcode-scan" routerLinkActive="active">Scan</a>
       <a routerLink="/challenge" routerLinkActive="active">Challenge</a>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { AnimateVideoComponent } from './components/animate-video/animate-video.
 import { MetahumanVideoComponent } from './components/metahuman-video/metahuman-video.component';
 import { BarcodeScanComponent } from './components/barcode-scan/barcode-scan.component';
 import { FashnTryOnComponent } from './components/fashn-try-on/fashn-try-on.component';
+import { ModelDressUpComponent } from './components/model-dress-up/model-dress-up.component';
 
 
 @NgModule({
@@ -49,6 +50,7 @@ import { FashnTryOnComponent } from './components/fashn-try-on/fashn-try-on.comp
     MetahumanVideoComponent,
     BarcodeScanComponent,
     FashnTryOnComponent,
+    ModelDressUpComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/model-dress-up/model-dress-up.component.html
+++ b/src/app/components/model-dress-up/model-dress-up.component.html
@@ -1,0 +1,12 @@
+<div class="model-container">
+  <img class="base" [src]="baseImage" alt="Model" />
+  <img
+    *ngFor="let piece of pieces"
+    class="piece"
+    [src]="piece.url"
+    cdkDrag
+    [style.z-index]="piece.layer"
+    [cdkDragFreeDragPosition]="{x: piece.x, y: piece.y}"
+    (cdkDragEnded)="onDragEnd($event, piece)"
+  />
+</div>

--- a/src/app/components/model-dress-up/model-dress-up.component.scss
+++ b/src/app/components/model-dress-up/model-dress-up.component.scss
@@ -1,0 +1,16 @@
+.model-container {
+  position: relative;
+  width: 220px;
+  height: 420px;
+  margin: 1rem auto;
+}
+
+.base {
+  width: 100%;
+}
+
+.piece {
+  position: absolute;
+  width: 80px;
+  cursor: move;
+}

--- a/src/app/components/model-dress-up/model-dress-up.component.ts
+++ b/src/app/components/model-dress-up/model-dress-up.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit } from '@angular/core';
+import { CdkDragEnd } from '@angular/cdk/drag-drop';
+import { FirebaseService } from '../../services/firebase.service';
+import { ClosetItem } from '../../models/closet-item';
+import { DEFAULT_OUTFITS } from '../../models/default-outfits';
+
+@Component({
+  selector: 'app-model-dress-up',
+  templateUrl: './model-dress-up.component.html',
+  styleUrls: ['./model-dress-up.component.scss']
+})
+export class ModelDressUpComponent implements OnInit {
+  baseImage = 'assets/model-silhouette.svg';
+  pieces: ClosetItem[] = [];
+
+  constructor(private firebaseService: FirebaseService) {}
+
+  ngOnInit(): void {
+    this.loadPieces();
+  }
+
+  async loadPieces(): Promise<void> {
+    const outfits = await this.firebaseService.getOutfits();
+    this.pieces = (outfits.length
+      ? outfits.map((o, idx) => ({
+          url: o.imageUrl,
+          category: o.category,
+          x: (idx - outfits.length / 2) * 120,
+          y: 0,
+        }))
+      : DEFAULT_OUTFITS.map((o, idx) => ({
+          ...o,
+          x: (idx - DEFAULT_OUTFITS.length / 2) * 120,
+          y: 0,
+        }))
+    ).map(p => ({ ...p, layer: 10 }));
+  }
+
+  onDragEnd(event: CdkDragEnd, piece: ClosetItem) {
+    const pos = event.source.getFreeDragPosition();
+    piece.x = pos.x;
+    piece.y = pos.y;
+  }
+}

--- a/src/assets/model-silhouette.svg
+++ b/src/assets/model-silhouette.svg
@@ -1,0 +1,8 @@
+<svg width="200" height="400" viewBox="0 0 200 400" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="100" cy="60" r="40" fill="#e6e6e6" />
+  <rect x="80" y="100" width="40" height="100" fill="#e6e6e6" />
+  <rect x="50" y="100" width="20" height="80" fill="#e6e6e6" />
+  <rect x="130" y="100" width="20" height="80" fill="#e6e6e6" />
+  <rect x="80" y="200" width="20" height="80" fill="#e6e6e6" />
+  <rect x="100" y="200" width="20" height="80" fill="#e6e6e6" />
+</svg>


### PR DESCRIPTION
## Summary
- create a simple SVG mannequin
- add a `ModelDressUpComponent` that lets users drag clothing images over a 2D model
- register component and route
- link to new page in navigation

## Testing
- `npm install`
- `npm test` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a77bda020832eacd591270f7c354d